### PR TITLE
Add hook priorities

### DIFF
--- a/Cmdr/Shared/Dispatcher.lua
+++ b/Cmdr/Shared/Dispatcher.lua
@@ -122,7 +122,7 @@ function Dispatcher:RunHooks(hookName, ...)
 	end
 
 	for _, hook in ipairs(self.Registry.Hooks[hookName]) do
-		local value = hook(...)
+		local value = hook.callback(...)
 
 		if value ~= nil then
 			return tostring(value)

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -175,12 +175,13 @@ function Registry:GetType (name)
 end
 
 --- Adds a hook to be called when any command is run
-function Registry:AddHook(hookName, callback)
+function Registry:AddHook(hookName, callback, priority)
 	if not self.Hooks[hookName] then
 		error(("Invalid hook name: %q"):format(hookName), 2)
 	end
 
-	table.insert(self.Hooks[hookName], callback)
+	table.insert(self.Hooks[hookName], { callback = callback; priority = priority or 0; } )
+	table.sort(self.Hooks[hookName], function(a, b) return a.priority < b.priority end)
 end
 
 --- Returns the store with the given name


### PR DESCRIPTION
#29 
Add a third parameter to `Registry:AddHook` that takes an optional integer indicating the priority of the hook. The lower the value, the higher the priority. The default is 0.