### PR TITLE
Add Registry Validation

### DIFF
--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -31,7 +31,7 @@ function Registry:RegisterType (name, typeObject)
 	end
 
 	if not name:find("^[%d%l]%w*$") then
-		error(('Invalid type name provided: "%s", type names must start with a lower-case letter and only contain letters.'):format(name))
+		error(('Invalid type name provided: "%s", type names must be alphanumeric and start with a lower-case letter or a digit.'):format(name))
 	end
 
 	for key in pairs(typeObject) do

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -30,7 +30,7 @@ function Registry:RegisterType (name, typeObject)
 		error("Invalid type name provided: nil")
 	end
 
-	if not name:find("^%l%w*$") then
+	if not name:find("^[%d%l]%w*$") then
 		error(('Invalid type name provided: "%s", type names must start with a lower-case letter and only contain letters.'):format(name))
 	end
 

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -1,3 +1,5 @@
+local RunService = game:GetService("RunService")
+
 local Util = require(script.Parent.Util)
 
 --- The registry keeps track of all the commands and types that Cmdr knows about.
@@ -69,6 +71,10 @@ function Registry:RegisterCommandObject (commandObject)
 				end
 			end
 		end
+	end
+
+	if RunService:IsClient() and commandObject.Data and commandObject.Run then
+		error(('Invalid command implementation provided for "%s": "Data" and "Run" sections are mutually exclusive'):format(commandObject.Name or "unknown"))
 	end
 
 	-- Unregister the old command if it exists...

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -26,6 +26,14 @@ local Registry = {
 --- Registers a type in the system.
 -- name: The type Name. This must be unique.
 function Registry:RegisterType (name, typeObject)
+	if not name or not typeof(name) == "string" then
+		error("Invalid type name provided: nil")
+	end
+
+	if not name:find("^%l%a*$") then
+		error(('Invalid type name provided: "%s", type names must start with a lower-case letter and only contain letters.'):format(name))
+	end
+
 	for key in pairs(typeObject) do
 		if self.TypeMethods[key] == nil then
 			error("Unknown key/method in type \"" .. name .. "\": " .. key)

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -30,7 +30,7 @@ function Registry:RegisterType (name, typeObject)
 		error("Invalid type name provided: nil")
 	end
 
-	if not name:find("^%l%a*$") then
+	if not name:find("^%l%w*$") then
 		error(('Invalid type name provided: "%s", type names must start with a lower-case letter and only contain letters.'):format(name))
 	end
 


### PR DESCRIPTION
This implementation throws errors on the client if a registered command has both a `Data` and `Run` section declared.
It also errors if a registered type's name is `nil`, if it isn't a string, if it contains anything other than letters, or doesn't start with a lowercase letter.