### PR TITLE
Add additional check for RoStrap installation

### DIFF
--- a/Cmdr/Initialize.lua
+++ b/Cmdr/Initialize.lua
@@ -16,7 +16,8 @@ return function (cmdr)
 
 	ReplicatedRoot = script.Parent.CmdrClient
 
-	if ReplicatedStorage:FindFirstChild("Resources") then -- If using RoStrap
+	if ReplicatedStorage:FindFirstChild("Resources") and
+		ReplicatedStorage.Resources:FindFirstChild("Libraries") then -- If using RoStrap
 		-- ReplicatedRoot.Name = "Cmdr"
 		ReplicatedRoot.Parent = ReplicatedStorage.Resources.Libraries
 	else


### PR DESCRIPTION
This should help prevent issues when there's a non-RoStrap object
named "Resources" in ReplicatedStorage.