### PR TITLE
Update docs/registry (RegisterHook) #94

### DIFF
--- a/docs/api/Registry.md
+++ b/docs/api/Registry.md
@@ -237,8 +237,8 @@ docs:
     - name: RegisterHook
       desc: Adds a hook. This should probably be run on the server, but can also work on the client. Hooks run in order of priority (lower number runs first).
       params:
-        - name: "BeforeRun" | "AfterRun"
-          type: string
+        - name: hookName
+          type: "BeforeRun" | "AfterRun"
         - name: callback
           type:
             kind: function

--- a/docs/api/Registry.md
+++ b/docs/api/Registry.md
@@ -237,7 +237,7 @@ docs:
     - name: RegisterHook
       desc: Adds a hook. This should probably be run on the server, but can also work on the client. Hooks run in order of priority (lower number runs first).
       params:
-        - name: hookName
+        - name: "BeforeRun" | "AfterRun"
           type: string
         - name: callback
           type:


### PR DESCRIPTION
RegisterHook's first parameter was called 'hookName' but is now called '"BeforeRun" | "AfterRun"' to be more clear to new users.