### PR TITLE
Disable AutoLocalize for Cmdr ScreenGui

### DIFF
--- a/Cmdr/CreateGui.lua
+++ b/Cmdr/CreateGui.lua
@@ -8,6 +8,7 @@ return function ()
 	Cmdr.DisplayOrder = 1000
 	Cmdr.Name = "Cmdr"
 	Cmdr.ResetOnSpawn = false
+	Cmdr.AutoLocalize = false
 
 	local Frame = Instance.new("ScrollingFrame")
 	Frame.BackgroundColor3 = Color3.fromRGB(17, 17, 17)


### PR DESCRIPTION
Fixes Cmdr input from being automatically captured and shown in the localization portal.

![firefox_YEjVZnT8Us](https://user-images.githubusercontent.com/48406739/73119172-d49c3b00-3f55-11ea-9f6c-ee6b22d04e49.png)
