### PR TITLE
Add utility method that takes server command implementations from a t…

### DIFF
--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -182,6 +182,24 @@ function Registry:RegisterCommandsIn (container, filter)
 	end
 end
 
+--- A helper method that registers all commands inside a specific container and sources the server implementations from a given table.
+function Registry:RegisterCommandsInContainerUsingTable (container, serverCmdTable)
+    for _, commandScript in pairs(container:GetChildren()) do
+        if commandScript:IsA("ModuleScript") then
+            local commandObject = require(commandScript)
+            local serverCommand = serverCmdTable[commandScript.Name]
+            if serverCommand then
+                commandObject.Run = serverCommand
+            end
+
+            self:RegisterCommandObject(commandObject)
+            commandScript.Parent = self.Cmdr.ReplicatedRoot.Commands
+        else
+            self:RegisterCommandsInContainerUsingTable(commandScript, serverCmdTable)
+        end
+    end
+end
+
 --- Registers the default commands, with an optional filter function or array of groups.
 function Registry:RegisterDefaultCommands (arrayOrFunc)
 	local isArray = type(arrayOrFunc) == "table"

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -150,7 +150,8 @@ function Util.SplitString(text, max)
 	text = encodeControlChars(text)
 	max = max or math.huge
 	local t = {}
-	local spat, epat, buf, quoted = [=[^(['"])]=], [=[(['"])$]=]
+	local spat, epat = [=[^(['"])]=], [=[(['"])$]=]
+	local buf, quoted
 	for str in text:gmatch("%S+") do
 		str = Util.ParseEscapeSequences(str)
 		local squoted = str:match(spat)


### PR DESCRIPTION
…able of functions in place of separate ModuleScripts.

An example of how this would be used:

`Cmdr:RegisterCommandsInContainerUsingTable(ServerScriptService.Commands, ServerCommands.Commands)`

_ServerCommands.lua_
```
local GameService

local ServerCommands = {}

function ServerCommands:Init()
    GameService = self.Services.GameService
end

function ServerCommands:OnCommandInvoked(context)
    print(string.format("%s invoked command %s!", context.Executor.Name, context.Name))
    return true
end

ServerCommands.Commands = {
    AddItem = function(context, toPlayer, itemType, itemId)
        local res = ServerCommands:OnCommandInvoked(context)
        if res then
            return GameService:AddItemCmd(toPlayer, itemType, itemId)
        else
            error(context.Executure.Name .. " is not allowed to run this command!")
        end
    end,

    AddResource = function(context, toPlayer, resourceType, resourceAmt)
        local res = ServerCommands:OnCommandInvoked(context)
        if res then
            return GameService:AddResourceCmd(toPlayer, resourceType, resourceAmt)
        else
            error(context.Executure.Name .. " is not allowed to run this command!")
        end
    end
}

return ServerCommands
```