### PR TITLE
Add Random Player Selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Add random selector for player type (#122)
+
 # v1.5.0
 
 - Adds AutoComplete IsPartial (#103)

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -30,7 +30,7 @@ local function ShorthandMultiple (text, executor)
 		if maxSize and maxSize > 0 then
 			local players = {}
 			local remainingPlayers = Players:GetPlayers()
-			for i = 1,math.min(maxSize, #remainingPlayers) do
+			for i = 1, math.min(maxSize, #remainingPlayers) do
 				table.insert(players,table.remove(remainingPlayers, math.random(1, #remainingPlayers)))
 			end
 			

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -4,6 +4,13 @@ local Players = game:GetService("Players")
 local function ShorthandSingle (text, executor)
 	if text == "." or text == "me" then
 		return {executor}
+	elseif text == "random" or text == "?" then
+		local players = Players:GetPlayers()
+		if #players <= 1 then
+			return players
+		else
+			return {players[math.random(1,#players)]}
+		end
 	end
 end
 
@@ -19,6 +26,23 @@ local function ShorthandMultiple (text, executor)
 			end
 		end
 		return Others
+	elseif (string.sub(text,1,7) == "random[" or string.sub(text,1,2) == "?[") and string.sub(text,string.len(text)) == "]" then
+		local maxSize = tonumber(string.match(text,"random%[(.+)%]")) or tonumber(string.match(text,"%?%[(.+)%]"))
+		if maxSize and maxSize > 0 then
+			local players = {}
+			local remainingPlayers = Players:GetPlayers()
+			for i = 1,math.min(maxSize,#remainingPlayers) do
+				local index = 1
+				if #remainingPlayers > 1 then
+					index = math.random(1,#remainingPlayers)
+				end
+				
+				table.insert(players,remainingPlayers[i])
+				table.remove(remainingPlayers,i)
+			end
+			
+			return players
+		end
 	end
 end
 

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -4,12 +4,12 @@ local Players = game:GetService("Players")
 local function ShorthandSingle (text, executor)
 	if text == "." or text == "me" then
 		return {executor}
-	elseif text == "random" or text == "?" then
+	elseif text == "?" then
 		local players = Players:GetPlayers()
 		if #players <= 1 then
 			return players
 		else
-			return {players[math.random(1,#players)]}
+			return {players[math.random(1, #players)]}
 		end
 	end
 end
@@ -26,13 +26,13 @@ local function ShorthandMultiple (text, executor)
 			end
 		end
 		return Others
-	elseif (string.sub(text,1,7) == "random[" or string.sub(text,1,2) == "?[") and string.sub(text,string.len(text)) == "]" then
-		local maxSize = tonumber(string.match(text,"random%[(.+)%]")) or tonumber(string.match(text,"%?%[(.+)%]"))
+	elseif string.match(text, "%?(%d+)") then
+		local maxSize = tonumber(string.match(text, "%?(%d+)"))
 		if maxSize and maxSize > 0 then
 			local players = {}
 			local remainingPlayers = Players:GetPlayers()
-			for i = 1,math.min(maxSize,#remainingPlayers) do
-				table.insert(players,table.remove(remainingPlayers,math.random(1,#remainingPlayers)))
+			for i = 1,math.min(maxSize, #remainingPlayers) do
+				table.insert(players,table.remove(remainingPlayers, math.random(1, #remainingPlayers)))
 			end
 			
 			return players

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -32,13 +32,7 @@ local function ShorthandMultiple (text, executor)
 			local players = {}
 			local remainingPlayers = Players:GetPlayers()
 			for i = 1,math.min(maxSize,#remainingPlayers) do
-				local index = 1
-				if #remainingPlayers > 1 then
-					index = math.random(1,#remainingPlayers)
-				end
-				
-				table.insert(players,remainingPlayers[i])
-				table.remove(remainingPlayers,i)
+				table.insert(players,table.remove(remainingPlayers,math.random(1,#remainingPlayers)))
 			end
 			
 			return players

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -22,8 +22,11 @@ local function ShorthandMultiple (text, executor)
 			end
 		end
 		return Others
-	elseif string.match(text, "%?(%d+)") then
-		local maxSize = tonumber(string.match(text, "%?(%d+)"))
+	end
+	
+	local randomMatch = text:match("%?(%d+)")
+	if randomMatch then
+		local maxSize = tonumber(randomMatch)
 		if maxSize and maxSize > 0 then
 			local players = {}
 			local remainingPlayers = Players:GetPlayers()

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -6,11 +6,7 @@ local function ShorthandSingle (text, executor)
 		return {executor}
 	elseif text == "?" then
 		local players = Players:GetPlayers()
-		if #players <= 1 then
-			return players
-		else
-			return {players[math.random(1, #players)]}
-		end
+		return {players[math.random(1, #players)]}
 	end
 end
 

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -31,7 +31,7 @@ local function ShorthandMultiple (text, executor)
 			local players = {}
 			local remainingPlayers = Players:GetPlayers()
 			for i = 1, math.min(maxSize, #remainingPlayers) do
-				table.insert(players,table.remove(remainingPlayers, math.random(1, #remainingPlayers)))
+				table.insert(players, table.remove(remainingPlayers, math.random(1, #remainingPlayers)))
 			end
 			
 			return players


### PR DESCRIPTION
# Purpose
The purpose of this pull request is to add the ability to select random players with the `player` and `players` datatype.

# Justification
Innovation Security (managed by non-developers) runs security trainings for the group and performs events. Some of these events rely on picking random players (between 1 and n), such as for snipers to stop everyone else from reaching the end of a map. The current syntax used as part of the older admin system (Nexus Admin) uses `random` as the selector, such as `:bring random,random,random` to bring 3 random players.

# Implementation Overview
The change requested involves adding both ~`random` and~ `?` to the `player` type as selectors for selecting random players, as well as being able to select a specific amount of random players using ~`random[n]` and `?[n]`~ `?n` (as mentioned in https://github.com/evaera/Cmdr/issues/121). This should not close the issue since it doesn't provide a robust solution for randomness/lists and is specific to players.

Edit: `random` and `random[n]` were removed and `?[n]` was changed to `?n` as requested from private messages.