### PR TITLE
Fixed so TextBox is not selectable using controller #124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - Add random selector for player type (#122)
+- Fixed so TextBox is not selectable using controller (#124)
 
 # v1.5.0
 

--- a/Cmdr/CreateGui.lua
+++ b/Cmdr/CreateGui.lua
@@ -1,8 +1,3 @@
---[[
-	DO NOT MODIFY. This file is auto-generated.
-	Plugin: https://www.roblox.com/library/2307140444/Object-to-Lua
-]]
-
 return function ()
 	local Cmdr = Instance.new("ScreenGui")
 	Cmdr.DisplayOrder = 1000
@@ -109,6 +104,7 @@ return function ()
 	TextBox.TextColor3 = Color3.fromRGB(255, 255, 255)
 	TextBox.TextSize = 14
 	TextBox.TextXAlignment = Enum.TextXAlignment.Left
+	TextBox.Selectable = false
 	TextBox.Parent = Entry
 
 	local TextLabel = Instance.new("TextLabel")


### PR DESCRIPTION
See #124 

I took the liberty to remove the auto-generated notice. Judging by the files currently in version control I assume that was some legacy method of creating this file.