### PR TITLE
Clear AutoExecBuffer on FlushAutoExecBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add random selector for player type (#122)
 - Fixed so TextBox is not selectable using controller (#124)
+- Fixed AutoExec commands being executed multiple times (#127)
 
 # v1.5.0
 

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -266,6 +266,8 @@ function Registry:FlushAutoExecBuffer()
 			self.Cmdr.Dispatcher:EvaluateAndRun(command)
 		end
 	end
+
+	self.AutoExecBuffer = {}
 end
 
 return function (cmdr)


### PR DESCRIPTION
# Purpose
The purpose of this pull request is to fix `AutoExec` commands being executed multiple times if a command is registered at a later frame, such as creating an alias.

# Implementation Overview
The change requested involves adding a clear for the `AutoExecBuffer` in the `FlushAutoExecBuffer` function. This clears the commands to execute and prevents them from being rerun when called.