### PR TITLE
Fix uninitialized variable Script Analysis warning

### DIFF
--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -150,7 +150,8 @@ function Util.SplitString(text, max)
 	text = encodeControlChars(text)
 	max = max or math.huge
 	local t = {}
-	local spat, epat, buf, quoted = [=[^(['"])]=], [=[(['"])$]=]
+	local spat, epat = [=[^(['"])]=], [=[(['"])$]=]
+	local buf, quoted
 	for str in text:gmatch("%S+") do
 		str = Util.ParseEscapeSequences(str)
 		local squoted = str:match(spat)


### PR DESCRIPTION
Util.SplitString has an initialization line where 4 variables are assigned to an expression with two values. This causes a linter warning in Script Analysis in Studio - "Assigning 2 values to 4 variables initializes extra variables with nil; add 'nil' to value list to silence".