### PR TITLE
Add HasImplementation function to CommandContext

### DIFF
--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -18,7 +18,14 @@ function Command.new (options)
 		Object = options.CommandObject; -- The command object (definition)
 		Group = options.CommandObject.Group; -- The group this command is in
 		State = {}; -- A table which will hold any custom command state information
-		HasClientRun = options.CommandObject.ClientRun and true or false; -- Checks if the command has client run function.
+		HasImplementation = function() --Returns true if the command has an implementation on the caller's machine.
+			if RunService:IsClient() then
+				return options.CommandObject.ClientRun and true or false
+			elseif RunService:IsServer() then
+				--Assuming the server implementation of the command is the Run function of CommandObject.
+				return options.CommandObject.Run and true or false
+			end
+		end
 		Aliases = options.CommandObject.Aliases;
 		Alias = options.Alias; -- The command name that was used
 		Description = options.CommandObject.Description;

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -217,10 +217,10 @@ end
 --- Returns true if the command has an implementation on the caller's machine.
 function Command:HasImplementation()
 	if RunService:IsClient() then
-		return options.CommandObject.ClientRun and true or false
+		return self.Object.ClientRun and true or false
 	elseif RunService:IsServer() then
 		--Assuming the server implementation of the command is the Run function of CommandObject.
-		return options.CommandObject.Run and true or false
+		return self.Object.Run and true or false
 	end
 end
 

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -18,6 +18,7 @@ function Command.new (options)
 		Object = options.CommandObject; -- The command object (definition)
 		Group = options.CommandObject.Group; -- The group this command is in
 		State = {}; -- A table which will hold any custom command state information
+		HasClientRun = options.CommandObject.ClientRun and true or false; -- Checks if the command has client run function.
 		Aliases = options.CommandObject.Aliases;
 		Alias = options.Alias; -- The command name that was used
 		Description = options.CommandObject.Description;

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -18,14 +18,6 @@ function Command.new (options)
 		Object = options.CommandObject; -- The command object (definition)
 		Group = options.CommandObject.Group; -- The group this command is in
 		State = {}; -- A table which will hold any custom command state information
-		HasImplementation = function() --Returns true if the command has an implementation on the caller's machine.
-			if RunService:IsClient() then
-				return options.CommandObject.ClientRun and true or false
-			elseif RunService:IsServer() then
-				--Assuming the server implementation of the command is the Run function of CommandObject.
-				return options.CommandObject.Run and true or false
-			end
-		end
 		Aliases = options.CommandObject.Aliases;
 		Alias = options.Alias; -- The command name that was used
 		Description = options.CommandObject.Description;
@@ -220,6 +212,16 @@ end
 --- Alias of Registry:GetStore(...)
 function Command:GetStore(...)
 	return self.Dispatcher.Cmdr.Registry:GetStore(...)
+end
+
+--- Returns true if the command has an implementation on the caller's machine.
+function Command:HasImplementation()
+	if RunService:IsClient() then
+		return options.CommandObject.ClientRun and true or false
+	elseif RunService:IsServer() then
+		--Assuming the server implementation of the command is the Run function of CommandObject.
+		return options.CommandObject.Run and true or false
+	end
 end
 
 return Command

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -216,12 +216,7 @@ end
 
 --- Returns true if the command has an implementation on the caller's machine.
 function Command:HasImplementation()
-	if RunService:IsClient() then
-		return self.Object.ClientRun and true or false
-	elseif RunService:IsServer() then
-		--Assuming the server implementation of the command is the Run function of CommandObject.
-		return self.Object.Run and true or false
-	end
+	return ((RunService:IsClient() and self.Object.ClientRun) or self.Object.Run) and true or false
 end
 
 return Command

--- a/docs/api/CommandContext.md
+++ b/docs/api/CommandContext.md
@@ -22,9 +22,11 @@ docs:
     - name: State
       desc: A blank table that can be used to store user-defined information about this command's current execution. This could potentially be used with hooks to add information to this table which your command or other hooks could consume.
       type: table
-    - name: HasClientRun
-      desc: Returns true if the command has ClientRun function.
-      type: boolean
+    - name: HasImplementation
+      desc: Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
+      Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
+      This function only answers one question if you run the command; does it run any code as a result of that on this machine?
+      type: function
     - name: Aliases
       type: array<string>
       desc: Any aliases that can be used to also trigger this command in addition to its name.

--- a/docs/api/CommandContext.md
+++ b/docs/api/CommandContext.md
@@ -23,9 +23,10 @@ docs:
       desc: A blank table that can be used to store user-defined information about this command's current execution. This could potentially be used with hooks to add information to this table which your command or other hooks could consume.
       type: table
     - name: HasImplementation
-      desc: Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
-      Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
-      This function only answers one question if you run the command; does it run any code as a result of that on this machine?
+      desc: |
+       Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
+       Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
+       This function only answers one question if you run the command; does it run any code as a result of that on this machine?
       type: function
     - name: Aliases
       type: array<string>

--- a/docs/api/CommandContext.md
+++ b/docs/api/CommandContext.md
@@ -67,10 +67,11 @@ docs:
       desc: Prints the given text in the user's console. Useful for when a command needs to print more than one message or is long-running. You should still `return` a string from the command implementation when you are finished, `Reply` should only be used to send additional messages before the final message.
     - name: HasImplementation
       desc: |
-       Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
+       Returns `true` if the command has an implementation on this machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
        Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
        This function only answers one question if you run the command; does it run any code as a result of that on this machine?
       returns: boolean
+      since: NEXT
 ---
 
 <ApiDocs />

--- a/docs/api/CommandContext.md
+++ b/docs/api/CommandContext.md
@@ -22,6 +22,9 @@ docs:
     - name: State
       desc: A blank table that can be used to store user-defined information about this command's current execution. This could potentially be used with hooks to add information to this table which your command or other hooks could consume.
       type: table
+    - name: HasClientRun
+      desc: Returns true if the command has ClientRun function.
+      type: boolean
     - name: Aliases
       type: array<string>
       desc: Any aliases that can be used to also trigger this command in addition to its name.

--- a/docs/api/CommandContext.md
+++ b/docs/api/CommandContext.md
@@ -22,12 +22,6 @@ docs:
     - name: State
       desc: A blank table that can be used to store user-defined information about this command's current execution. This could potentially be used with hooks to add information to this table which your command or other hooks could consume.
       type: table
-    - name: HasImplementation
-      desc: |
-       Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
-       Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
-       This function only answers one question if you run the command; does it run any code as a result of that on this machine?
-      type: function
     - name: Aliases
       type: array<string>
       desc: Any aliases that can be used to also trigger this command in addition to its name.
@@ -71,6 +65,12 @@ docs:
     - name: Reply
       params: "text: string, color: Color3?"
       desc: Prints the given text in the user's console. Useful for when a command needs to print more than one message or is long-running. You should still `return` a string from the command implementation when you are finished, `Reply` should only be used to send additional messages before the final message.
+    - name: HasImplementation
+      desc: |
+       Returns `true` if the command has an implementation on the caller's machine. For example, this function will return `false` from the client if you call it on a command that only has a server-side implementation.
+       Note that commands can potentially run on both the client and the server, so what this property returns on the server is not related to what it returns on the client, and vice versa. Likewise, receiving a return value of `true` on the client does not mean that the command won't run on the server, because Cmdr commands can run a first part on the client and a second part on the server.
+       This function only answers one question if you run the command; does it run any code as a result of that on this machine?
+      returns: boolean
 ---
 
 <ApiDocs />


### PR DESCRIPTION
I made a BeforeRun and AfterRun hook on client, it sends the info to remote function(to validate things on server) then returns the response, the thing is while client commands get validated and logged 1 times on the server, Server commands get 2 times because both the client sends info and server has the hooks.

This will allow me(and others) to check if the command is client sided then sends the info so it doesnt get double validated and logged.