### PR TITLE
Fix GUI replicating twice

### DIFF
--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -39,7 +39,7 @@ local Cmdr do
 	Cmdr.Dispatcher = require(Shared.Dispatcher)(Cmdr)
 end
 
-if StarterGui:WaitForChild("Cmdr") and wait() and Player:WaitForChild("PlayerGui"):FindFirstChild("Cmdr") == nil then
+if Player.Character ~= nil and StarterGui:WaitForChild("Cmdr") and Player:WaitForChild("PlayerGui"):FindFirstChild("Cmdr") == nil then
 	StarterGui.Cmdr:Clone().Parent = Player.PlayerGui
 end
 


### PR DESCRIPTION
Fixes #125. Checks if the character has already been loaded before cloning in the GUI.
