### PR TITLE
Update endingUnit String Pattern

### DIFF
--- a/Cmdr/BuiltInTypes/Duration.lua
+++ b/Cmdr/BuiltInTypes/Duration.lua
@@ -90,7 +90,7 @@ local durationType = {
                 returnTable = mapUnits(unitsTable, rawText, existingUnitLength + 1)
             end
         elseif duration ~= nil then
-            local endingUnit = rawText:match("^.*-?%d+(%a+)$")
+            local endingUnit = rawText:match("^.*-?%d+(%a+)%s?$")
             -- Assume there is a singular match at this point
             local fuzzyUnits = unitFinder(endingUnit)
             -- List all possible fuzzy matches. This is for the Minutes/Months ambiguity case.


### PR DESCRIPTION
This commit catches whitespace added by pressing enter (if any) after the ending unit (second/minute/hour/day). Without the added %s?, endingUnit would be nil.