### PR TITLE
Organize the help command

### DIFF
--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -1,4 +1,4 @@
-local ARGUMENT_SHORTHANDS = ([[
+local ARGUMENT_SHORTHANDS = [[
 Argument Shorthands
 -------------------			
 .   Me/Self
@@ -6,7 +6,7 @@ Argument Shorthands
 **  Others 
 ?   Random
 ?N  List of N random values			
-]])
+]]
 
 return {
 	Name = "help";

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -1,3 +1,13 @@
+local ARGUMENT_SHORTHANDS = ([[
+Argument Shorthands
+-------------------			
+.   Me/Self
+*   All/Everyone 
+**  Others 
+?   Random
+?N  List of N random values			
+]])
+
 return {
 	Name = "help";
 	Description = "Displays a list of all commands, or inspects one command.";
@@ -29,27 +39,17 @@ return {
 			end
 		else
 			local commands = context.Cmdr.Registry:GetCommands()
-			local groups = context.Cmdr.Registry:GetGroups()
-			
-			context:Reply([[
-Notes to consider!
-------------------
-. = Me/Self
-* = All/Everyone
-** = Others
-? = Random
-?N = List of N random values	
-]])
-			for _, groupName in pairs(groups) do
-				context:Reply(([[
-%s
-------------------
-]]):format(groupName))
-				for _, cmd in pairs(commands) do
-					if cmd.Group == groupName then
-						context:Reply(("%s - %s"):format(cmd.Name, cmd.Description))
-					end
+			table.sort(commands, function(a, b)
+				return a.Group < b.Group
+			end)
+			context:Reply(ARGUMENT_SHORTHANDS)
+			local lastGroup
+			for _, command in pairs(commands) do
+				if lastGroup ~= command.Group then
+					context:Reply(("\n%s\n-------------------"):format(command.Group))
+					lastGroup = command.Group	
 				end
+				context:Reply(("%s - %s"):format(command.Name, command.Description))
 			end
 		end
 		return ""

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -36,8 +36,9 @@ Notes to consider!
 ------------------
 . = Me/Self
 * = All/Everyone
-? = Random
 ** = Others
+? = Random
+?N = List of N random values	
 ]])
 			for _, groupName in pairs(groups) do
 				context:Reply(([[

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -38,13 +38,14 @@ return {
 				))
 			end
 		else
+			context:Reply(ARGUMENT_SHORTHANDS)
+
 			local commands = context.Cmdr.Registry:GetCommands()
 			table.sort(commands, function(a, b)
 				return a.Group < b.Group
 			end)
-			context:Reply(ARGUMENT_SHORTHANDS)
 			local lastGroup
-			for _, command in pairs(commands) do
+			for _, command in ipairs(commands) do
 				if lastGroup ~= command.Group then
 					context:Reply(("\n%s\n-------------------"):format(command.Group))
 					lastGroup = command.Group	

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -29,9 +29,26 @@ return {
 			end
 		else
 			local commands = context.Cmdr.Registry:GetCommands()
-
-			for _, cmd in pairs(commands) do
-				context:Reply(("%s - %s"):format(cmd.Name, cmd.Description))
+			local groups = context.Cmdr.Registry:GetGroups()
+			
+			context:Reply([[
+Notes to consider!
+------------------
+. = Me/Self
+* = All/Everyone
+? = Random
+** = Others
+]])
+			for _, groupName in pairs(groups) do
+				context:Reply(([[
+%s
+------------------
+]]):format(groupName))
+				for _, cmd in pairs(commands) do
+					if cmd.Group == groupName then
+						context:Reply(("%s - %s"):format(cmd.Name, cmd.Description))
+					end
+				end
 			end
 		end
 		return ""

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -215,6 +215,20 @@ end
 
 Registry.GetCommandsAsStrings = Registry.GetCommandNames
 
+--- Returns and array of all registered command groups
+function Registry:GetGroups()
+	local groups = {}
+
+	for _, group in pairs(Registry:GetCommands()) do
+		if not table.find(groups, group.Group) then
+			table.insert(groups, group.Group)
+		end
+	end
+	table.sort(groups)
+	
+	return groups
+end
+
 --- Returns an array of the names of all registered types (not including aliases)
 function Registry:GetTypeNames ()
 	local typeNames = {}

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -215,20 +215,6 @@ end
 
 Registry.GetCommandsAsStrings = Registry.GetCommandNames
 
---- Returns and array of all registered command groups
-function Registry:GetGroups()
-	local groups = {}
-
-	for _, group in pairs(Registry:GetCommands()) do
-		if not table.find(groups, group.Group) then
-			table.insert(groups, group.Group)
-		end
-	end
-	table.sort(groups)
-	
-	return groups
-end
-
 --- Returns an array of the names of all registered types (not including aliases)
 function Registry:GetTypeNames ()
 	local typeNames = {}


### PR DESCRIPTION
Categorize the commands displayed by the groups pulled from each command definition for easier readability.