### PR TITLE
Change how tables are indexed

### DIFF
--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -118,7 +118,7 @@ function Registry:RegisterCommandObject (commandObject, fromCmdr)
 			self.Commands[alias:lower()] = nil
 		end
 	elseif not oldCommand then
-		self.CommandsArray[#self.CommandsArray + 1] = commandObject
+		table.insert(self.CommandsArray, commandObject)
 	end
 
 	self.Commands[commandObject.Name:lower()] = commandObject
@@ -207,7 +207,7 @@ function Registry:GetCommandNames ()
 	local commands = {}
 
 	for _, command in pairs(self.CommandsArray) do
-		commands[#commands + 1] = command.Name
+		table.insert(commands, command.Name)
 	end
 
 	return commands
@@ -220,7 +220,7 @@ function Registry:GetTypeNames ()
 	local typeNames = {}
 
 	for typeName in pairs(self.Types) do
-		typeNames[#typeNames + 1] = typeName
+		table.insert(typeNames, typeName)
 	end
 
 	return typeNames


### PR DESCRIPTION
t[#t + 1] = x has been superseded by table.insert(t, x).