### PR TITLE
Replace TeleportPartyAsync with TeleportAsync

### DIFF
--- a/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
@@ -1,19 +1,4 @@
-local AssetService = game:GetService("AssetService")
 local TeleportService = game:GetService("TeleportService")
-
-local pages = AssetService:GetGamePlacesAsync()
-local places = {}
-
-while true do
-	for _, place in ipairs(pages:GetCurrentPage()) do
-		table.insert(places, place.PlaceId)
-	end
-
-	if pages.isFinished then
-		break
-	end
-	pages:AdvanceToNextpageAsync()
-end
 
 return function(context, players, placeId, jobId)
 	players = players or { context.Executor }
@@ -31,11 +16,7 @@ return function(context, players, placeId, jobId)
 			TeleportService:TeleportToPlaceInstance(placeId, jobId, player)
 		end
 	else
-		if table.find(places, placeId) then
-			TeleportService:TeleportPartyAsync(placeId, players)
-		else
-			TeleportService:TeleportAsync(placeId, players)
-		end
+		TeleportService:TeleportAsync(placeId, players)
 	end
 
 	return "Teleported."

--- a/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
@@ -16,7 +16,7 @@ return function(context, players, placeId, jobId)
 			TeleportService:TeleportToPlaceInstance(placeId, jobId, player)
 		end
 	else
-		TeleportService:TeleportPartyAsync(placeId, players)
+		TeleportService:TeleportAsync(placeId, players)
 	end
 
 	return "Teleported."

--- a/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/gotoPlaceServer.lua
@@ -1,7 +1,22 @@
+local AssetService = game:GetService("AssetService")
 local TeleportService = game:GetService("TeleportService")
 
+local pages = AssetService:GetGamePlacesAsync()
+local places = {}
+
+while true do
+	for _, place in ipairs(pages:GetCurrentPage()) do
+		table.insert(places, place.PlaceId)
+	end
+
+	if pages.isFinished then
+		break
+	end
+	pages:AdvanceToNextpageAsync()
+end
+
 return function(context, players, placeId, jobId)
-	players = players or { context.Executor}
+	players = players or { context.Executor }
 
 	if placeId <= 0 then
 		return "Invalid place ID"
@@ -16,7 +31,11 @@ return function(context, players, placeId, jobId)
 			TeleportService:TeleportToPlaceInstance(placeId, jobId, player)
 		end
 	else
-		TeleportService:TeleportAsync(placeId, players)
+		if table.find(places, placeId) then
+			TeleportService:TeleportPartyAsync(placeId, players)
+		else
+			TeleportService:TeleportAsync(placeId, players)
+		end
 	end
 
 	return "Teleported."


### PR DESCRIPTION
TeleportPartyAsync can only teleport to a place in the same universe. I replaced it with the new TeleportAsync, which can teleport to places in a different universe.