### PR TITLE
Prevent quadratic backtracking in TrimString function

### DIFF
--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -219,8 +219,9 @@ function Util.MashExcessArguments(arguments, max)
 end
 
 --- Trims whitespace from both sides of a string.
-function Util.TrimString(s)
-	return s:match "^%s*(.-)%s*$"
+function Util.TrimString(str)
+	local from = string.match(str, "^%s*()")
+	return from > #str and "" or string.match(str, ".*%S", from) -- this check is to prevent quadratic backtracking
 end
 
 --- Returns the text bounds size based on given text, label (from which properties will be pulled), and optional Vector2 container size.

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -220,8 +220,9 @@ end
 
 --- Trims whitespace from both sides of a string.
 function Util.TrimString(str)
-	local from = string.match(str, "^%s*()")
-	return from > #str and "" or string.match(str, ".*%S", from) -- this check is to prevent quadratic backtracking
+	local _, from = string.find(str, "^%s*")
+	-- trim the string in two steps to prevent quadratic backtracking when no "%S" match is found
+	return from == #str and "" or string.match(str, ".*%S", from + 1)
 end
 
 --- Returns the text bounds size based on given text, label (from which properties will be pulled), and optional Vector2 container size.


### PR DESCRIPTION
The pattern "^%s*(.-)%s*$" doesn't do well for strings that have a large number of whitespace characters between non-whitespace characters.

Inspired by: https://stackstatus.net/post/147710624694/outage-postmortem-july-20-2016
Test bench: https://gist.github.com/Validark/c86a3e92dde76d26e6893d796dfea89a