### PR TITLE
Improve run-lines Functionality

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/runLines.lua
+++ b/Cmdr/BuiltInCommands/Utility/runLines.lua
@@ -12,12 +12,12 @@ return {
 		}
 	};
 
-	Run = function(context, text)
+	ClientRun = function(context, text)
 		if #text == 0 then
 			return ""
 		end
 
-		local shouldPrintOutput = context.Dispatcher:EvaluateAndRun("var INIT_PRINT_OUTPUT", context.Executor) ~= ""
+		local shouldPrintOutput = context.Dispatcher:Run("var", "INIT_PRINT_OUTPUT") ~= ""
 
 		local commands = text:gsub("\n+", "\n"):split("\n")
 
@@ -26,7 +26,7 @@ return {
 				continue
 			end
 
-			local output = context.Dispatcher:EvaluateAndRun(command, context.Executor)
+			local output = context.Dispatcher:EvaluateAndRun(command)
 
 			if shouldPrintOutput then
 				context:Reply(output)

--- a/Cmdr/BuiltInCommands/Utility/runLines.lua
+++ b/Cmdr/BuiltInCommands/Utility/runLines.lua
@@ -17,7 +17,7 @@ return {
 			return ""
 		end
 
-		local shouldPrintOutput = context.Dispatcher:Run("var", "INIT_PRINT_OUTPUT") ~= ""
+		local shouldPrintOutput = context.Dispatcher:EvaluateAndRun("var INIT_PRINT_OUTPUT", context.Executor) ~= ""
 
 		local commands = text:gsub("\n+", "\n"):split("\n")
 
@@ -26,7 +26,7 @@ return {
 				continue
 			end
 
-			local output = context.Dispatcher:EvaluateAndRun(command)
+			local output = context.Dispatcher:EvaluateAndRun(command, context.Executor)
 
 			if shouldPrintOutput then
 				context:Reply(output)

--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -28,9 +28,15 @@ Line.Parent = nil
 
 --- Update the text entry label
 function Window:UpdateLabel()
+	local PlayerNameSize = TextService:GetTextSize(
+		Player.Name .. "@" .. self.Cmdr.PlaceName .. "$",
+		Entry.TextLabel.TextSize,
+		Entry.TextLabel.Font,
+		Vector2.new(math.huge, math.huge)
+	)
 	Entry.TextLabel.Text = Player.Name .. "@" .. self.Cmdr.PlaceName .. "$"
-	Entry.TextLabel.Size = UDim2.new(0, Entry.TextLabel.TextBounds.X, 0, 20)
-	Entry.TextBox.Position = UDim2.new(0, Entry.TextLabel.Size.X.Offset + 7, 0, 0)
+	Entry.TextLabel.Size = UDim2.new(0, PlayerNameSize.X, 0, 20)
+	Entry.TextBox.Position = UDim2.new(0, PlayerNameSize.X + 7, 0, 0)
 end
 
 --- Get the text entry label

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -312,7 +312,7 @@ function Util.RunCommandString(dispatcher, commandString)
 
 	local output = ""
 	for i, command in ipairs(commands) do
-		local outputEncoded = output:gsub("%$", "\\x24")
+		local outputEncoded = output:gsub("%$", "\\x24"):gsub("%%","%%%%")
 		command = command:gsub("||", output:find("%s") and ("%q"):format(outputEncoded) or outputEncoded)
 
 		output = tostring(


### PR DESCRIPTION
While working with Innovation Security, we discovered a couple of things with respect to `run-lines` when using `init-edit` and `init-run`:
- By default, it doesn't appear to work at all since it uses `Dispatcher:Run(...)`, which only works on the client, but is called by the server.
- `run-lines` does not work with client commands, like `alias`.
- `run-lines` throws an error if the input text contains a percent character anywhere.

This pull request attempts to address those problems by making `run-lines` run on the client instead of the server, and escape percent characters before being used with `gsub`.