### PR TITLE
Add Wally manifest

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,28 +1,6 @@
 {
 	"name": "Cmdr",
 	"tree": {
-		"$className": "DataModel",
-		"ServerScriptService": {
-			"$className": "ServerScriptService",
-			"Repository": {
-				"$ignoreUnknownInstances": true,
-				"$className": "Folder",
-				"Vendor": {
-					"$className": "Folder",
-					"$ignoreUnknownInstances": true,
-					"Cmdr": {
-						"$className": "Folder",
-						"$ignoreUnknownInstances": true,
-						"Server": {
-							"$className": "Folder",
-							"$ignoreUnknownInstances": true,
-							"Cmdr": {
-								"$path": "./Cmdr"
-							}
-						}
-					}
-				}
-			}
-		}
+		"$path": "Cmdr"
 	}
 }

--- a/test-place.project.json
+++ b/test-place.project.json
@@ -1,0 +1,28 @@
+{
+	"name": "Cmdr",
+	"tree": {
+		"$className": "DataModel",
+		"ServerScriptService": {
+			"$className": "ServerScriptService",
+			"Repository": {
+				"$ignoreUnknownInstances": true,
+				"$className": "Folder",
+				"Vendor": {
+					"$className": "Folder",
+					"$ignoreUnknownInstances": true,
+					"Cmdr": {
+						"$className": "Folder",
+						"$ignoreUnknownInstances": true,
+						"Server": {
+							"$className": "Folder",
+							"$ignoreUnknownInstances": true,
+							"Cmdr": {
+								"$path": "./Cmdr"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,9 @@
+[package]
+name = "evaera/cmdr"
+description = "Extensible command console for Roblox developers"
+version = "1.8.4"
+license = "MIT"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependencies]


### PR DESCRIPTION
(This is a trial of a batch of PRs that I'm sending around to a bunch of repositories. I've talked about this with Eryn, let's iron out the wrinkles here before I go and open a bunch of other PRs!)

Hello!

This PR adds a manifest file for [Wally][wally], a new package manager created for Roblox by Uplift Games.

## About Wally
This change enables users to install this package by adding a line to their `wally.toml` manifest:

```toml
[package]
name = "lucien/my-game"
version = "0.1.0"
registry = "https://github.com/UpliftGames/wally-index"
realm = "shared"

[dependencies]
Cmdr = "evaera/cmdr@1.8.4"
```

We're currently running a soft rollout for wally where Uplift Games publishes packages on behalf of library authors. In the near future, library authors will be able to publish packages themselves.

Wally works like most modern language package managers and has a central registry. Merging this pull request enables your package to be published to the Wally registry. We will also publish versions on your behalf until Wally's self-service functionality is completed.

If you would not like your package to be available via Wally, feel free to close this pull request. This is always something that can be revisited later!

## Other Changes
If applicable, this PR also makes a couple small changes to your Rojo configuration. Wally requires that `default.project.json` produces a model containing just your library, not including any test place or extra glue.

[wally]: https://github.com/UpliftGames/wally
