### PR TITLE
Start implementing filesystem

### DIFF
--- a/Cmdr/BuiltInCommands/Debug/Tree/cd.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/cd.lua
@@ -1,0 +1,25 @@
+return {
+	Name = "cd",
+	Description = "Changes the current working directory, or outputs it.",
+	Group = "DefaultDebug",
+	Args = {
+		{
+			Type = "pathname",
+			Name = "Instance",
+			Description = "The instance to change the cd to. Can be a relative path or a full path. If omitted, outputs the cd.",
+			Optional = true
+		}
+	},
+	AutoExec = {
+		"cd ~"
+	},
+	ClientRun = function(context, pathname)
+		local cmdr = context.Cmdr
+		local Directory = cmdr.Directory
+
+		if pathname then
+			Directory:SetCD(pathname)
+		end
+		return Directory:GetCD()
+	end
+} 

--- a/Cmdr/BuiltInCommands/Debug/Tree/cd.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/cd.lua
@@ -10,12 +10,9 @@ return {
 			Optional = true
 		}
 	},
-	AutoExec = {
-		"cd ~"
-	},
 	ClientRun = function(context, pathname)
-		local cmdr = context.Cmdr
-		local Directory = cmdr.Directory
+		-- Get the local directory for the player
+		local Directory = context.Directory
 
 		if pathname then
 			Directory:SetCD(pathname)

--- a/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
@@ -18,12 +18,13 @@ return {
 		local instance = pathname and Directory:GetInstance(pathname)
 
 		-- Get the instance at the current directory
-		if not instance then
+		if not pathname then
 			instance = Directory:GetInstance("./")
+		end
 
-			if not instance then
-				return "# The current directory is invalid."
-			end
+		-- Return an error if there's no instance
+		if not instance then
+			return "# The directory is invalid."
 		end
 
 		-- List all children

--- a/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
@@ -4,27 +4,24 @@ return {
 	Group = "DefaultDebug",
 	Args = {
 		{
-			Type = "pathname",
+			Type = "instance",
 			Name = "Instance",
 			Description = "The path of the target relative to the cd.",
 			Optional = true
 		}
 	},
-	ClientRun = function(context, pathname)
+	ClientRun = function(context, instance)
 		-- Get the local directory for the player
 		local Directory = context.Directory
 
-		-- Get the instance
-		local instance = pathname and Directory:GetInstance(pathname)
-
-		-- Get the instance at the current directory
-		if not pathname then
-			instance = Directory:GetInstance("./")
+		-- Return an error if there's no instance
+		if instance == false then
+			return "# The directory is invalid."
 		end
 
-		-- Return an error if there's no instance
+		-- Get the instance at the current directory if not specified
 		if not instance then
-			return "# The directory is invalid."
+			instance = Directory:GetInstance("./")
 		end
 
 		-- List all children

--- a/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
@@ -4,15 +4,18 @@ return {
 	Group = "DefaultDebug",
 	Args = {
 		{
-			Type = "instance",
+			Type = "pathname",
 			Name = "Instance",
 			Description = "The path of the target relative to the cd.",
 			Optional = true
 		}
 	},
-	ClientRun = function(context, instance)
-		local cmdr = context.Cmdr
-		local Directory = cmdr.Directory
+	ClientRun = function(context, pathname)
+		-- Get the local directory for the player
+		local Directory = context.Directory
+
+		-- Get the instance
+		local instance = pathname and Directory:GetInstance(pathname)
 
 		-- Get the instance at the current directory
 		if not instance then
@@ -23,6 +26,7 @@ return {
 			end
 		end
 
+		-- List all children
 		local results = {}
 		for _, child in ipairs(instance:GetChildren()) do
 			local success, name = pcall(tostring, child)

--- a/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
+++ b/Cmdr/BuiltInCommands/Debug/Tree/ls.lua
@@ -1,0 +1,35 @@
+return {
+	Name = "ls",
+	Description = "Lists the instances in the current path.",
+	Group = "DefaultDebug",
+	Args = {
+		{
+			Type = "instance",
+			Name = "Instance",
+			Description = "The path of the target relative to the cd.",
+			Optional = true
+		}
+	},
+	ClientRun = function(context, instance)
+		local cmdr = context.Cmdr
+		local Directory = cmdr.Directory
+
+		-- Get the instance at the current directory
+		if not instance then
+			instance = Directory:GetInstance("./")
+
+			if not instance then
+				return "# The current directory is invalid."
+			end
+		end
+
+		local results = {}
+		for _, child in ipairs(instance:GetChildren()) do
+			local success, name = pcall(tostring, child)
+			if success then
+				table.insert(results, name)
+			end
+		end
+		return table.concat(results, "\n")
+	end
+} 

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -15,7 +15,7 @@ local function fuzzyFind(value)
 	return Directory:GetInstance(prefix), prefix, suffix
 end
 
-local pathnamePathType = {
+local pathnameType = {
 	DisplayName = "pathname",
 	Validate = function(value)
 		return fuzzyFind(value) ~= nil, "Not a valid instance '" .. value .. "'"
@@ -52,12 +52,17 @@ local pathnamePathType = {
 		return Directory.new(player):GetCD()
 	end,
 	Parse = function(value)
-		-- Would need to know which player is parsing this type to properly handle things like home directories
-		-- return Directory:ResolveAbsolutePathname(value)
-		return value
+		return Directory:ResolveAbsolutePathname(value) or false
 	end
 }
 
+local instanceType = setmetatable({
+	Parse = function(value)
+		return Directory:GetInstance(value)
+	end
+}, {__index = pathnameType})
+
 return function(registry)
-	registry:RegisterType("pathname", pathnamePathType)
+	registry:RegisterType("pathname", pathnameType)
+	registry:RegisterType("instance", instanceType)
 end

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -1,4 +1,4 @@
-local Directory = require(script.Parent.Parent.Shared.Directory)
+local Directory = require(script.Parent.Parent.Shared.Directory).new()
 
 local autocompleteSettings = {
 	IsPartial = true

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -59,7 +59,10 @@ local pathnameType = {
 local instanceType = setmetatable({
 	Parse = function(value)
 		return Directory:GetInstance(value)
-	end
+	end,
+	Default = function(player)
+		return Directory:GetInstance(Directory.new(player):GetCD())
+	end,
 }, {__index = pathnameType})
 
 return function(registry)

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -1,0 +1,67 @@
+local Directory = require(script.Parent.Parent.Shared.Directory)
+
+local autocompleteSettings = {
+	IsPartial = true
+}
+
+local FUZZY_PREFIX_PATTERN = "^(.*/)(.*)$"
+local function fuzzyFind(value)
+	local prefix, suffix = string.match(value, FUZZY_PREFIX_PATTERN)
+	
+	if not prefix then
+		return Directory:GetInstance("./"), "", value
+	end
+	return Directory:GetInstance(prefix), prefix, suffix
+end
+
+local pathnamePathType = {
+	DisplayName = "pathname",
+	Validate = function(value)
+		return fuzzyFind(value) ~= nil, "Not a valid instance '" .. value .. "'"
+	end,
+	Autocomplete = function(value)
+		local paths = {}
+
+		local instance, prefix, suffix = fuzzyFind(value)
+		if instance then
+			-- Insert the paths of each child
+			for _, child in ipairs(instance:GetChildren()) do
+				local success, name = pcall(tostring, child)
+				if success then
+					local suffixStart, suffixEnd = string.find(name, suffix, nil, true)
+					if suffixStart then
+						table.insert(paths, prefix .. Directory:JoinPaths(suffix .. string.sub(name, suffixEnd + 1)))
+					end
+				end
+			end
+
+			if string.find("..", suffix, nil, true) then
+				table.insert(paths, 1, prefix .. "..")
+			end
+
+			-- If the paths are empty we should skip to the next argument
+			if #paths == 1 then
+				return paths
+			end
+		end
+
+		return paths, autocompleteSettings
+	end,
+	Default = function(player)
+		return Directory:GetCD()
+	end,
+	Parse = function(value)
+		return Directory:ResolveAbsolutePathname(value)
+	end
+}
+
+local instancePathType = setmetatable({
+	Parse = function(value)
+		return Directory:GetInstance(value)
+	end
+}, {__index = pathnamePathType})
+
+return function(registry)
+	registry:RegisterType("pathname", pathnamePathType)
+	registry:RegisterType("instance", instancePathType)
+end

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -4,12 +4,13 @@ local autocompleteSettings = {
 	IsPartial = true
 }
 
-local FUZZY_PREFIX_PATTERN = "^(.*/)(.*)$"
+-- TODO: Escape separator?
+local FUZZY_PREFIX_PATTERN = "^(.*" .. Directory.PATH_SEPARATOR .. ")(.*)$"
 local function fuzzyFind(value)
 	local prefix, suffix = string.match(value, FUZZY_PREFIX_PATTERN)
 	
 	if not prefix then
-		return Directory:GetInstance("./"), "", value
+		return Directory:GetInstance(Directory.CD_WORD .. Directory.PATH_SEPARATOR), "", value
 	end
 	return Directory:GetInstance(prefix), prefix, suffix
 end
@@ -35,8 +36,8 @@ local pathnamePathType = {
 				end
 			end
 
-			if string.find("..", suffix, nil, true) then
-				table.insert(paths, 1, prefix .. "..")
+			if string.find(Directory.PARENT_WORD, suffix, nil, true) then
+				table.insert(paths, 1, prefix .. Directory.PARENT_WORD)
 			end
 
 			-- If the paths are empty we should skip to the next argument

--- a/Cmdr/BuiltInTypes/PathName.lua
+++ b/Cmdr/BuiltInTypes/PathName.lua
@@ -48,20 +48,15 @@ local pathnamePathType = {
 		return paths, autocompleteSettings
 	end,
 	Default = function(player)
-		return Directory:GetCD()
+		return Directory.new(player):GetCD()
 	end,
 	Parse = function(value)
-		return Directory:ResolveAbsolutePathname(value)
+		-- Would need to know which player is parsing this type to properly handle things like home directories
+		-- return Directory:ResolveAbsolutePathname(value)
+		return value
 	end
 }
 
-local instancePathType = setmetatable({
-	Parse = function(value)
-		return Directory:GetInstance(value)
-	end
-}, {__index = pathnamePathType})
-
 return function(registry)
 	registry:RegisterType("pathname", pathnamePathType)
-	registry:RegisterType("instance", instancePathType)
 end

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -4,6 +4,7 @@ local Players = game:GetService("Players")
 local Player = Players.LocalPlayer
 local Shared = script:WaitForChild("Shared")
 local Util = require(Shared:WaitForChild("Util"))
+local Directory = require(Shared:WaitForChild("Directory"))
 
 if RunService:IsClient() == false then
 	error("Server scripts cannot require the client library. Please require the server library to use Cmdr in your own code.")
@@ -21,6 +22,7 @@ local Cmdr do
 		HideOnLostFocus = true;
 		PlaceName = "Cmdr";
 		Util = Util;
+		Directory = Directory;
 		Events = {};
 	}, {
 		-- This sucks, and may be redone or removed

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -1,6 +1,7 @@
 local RunService = game:GetService("RunService")
 local Players = game:GetService("Players")
 local Argument = require(script.Parent.Argument)
+local Directory = require(script.Parent.Directory)
 
 local IsServer = RunService:IsServer()
 
@@ -13,6 +14,7 @@ function Command.new (options)
 	local self = {
 		Dispatcher = options.Dispatcher; -- The dispatcher that created this command context
 		Cmdr = options.Dispatcher.Cmdr; -- A quick reference to Cmdr for command context
+		Directory = Directory.new(options.Executor); -- A Directory object owned by the executor
 		Name = options.CommandObject.Name; -- The command name (not alias)
 		RawText = options.Text; -- The raw text used to trigger this command
 		Object = options.CommandObject; -- The command object (definition)

--- a/Cmdr/Shared/Directory.lua
+++ b/Cmdr/Shared/Directory.lua
@@ -173,10 +173,8 @@ end
 local directories = {}
 function Directory.new(player)
 	player = player or Players.LocalPlayer
-	if not RunService:IsServer() then
-		if not player then
-			return Directory
-		end
+	if not player then
+		return Directory
 	end
 
 	local existing = directories[player]

--- a/Cmdr/Shared/Directory.lua
+++ b/Cmdr/Shared/Directory.lua
@@ -1,0 +1,190 @@
+local RunService = game:GetService("RunService")
+
+local Directory = {
+	HomeStack = {}
+}
+Directory.__index = Directory
+
+-- Directory symbols
+local HOME_WORD = "~"
+local PARENT_WORD = ".."
+local CD_WORD = "."
+local PATH_SEPARATOR = "/"
+
+-- Root instance
+local ROOT_INSTANCE = game
+
+-- Gets the current directory
+function Directory:GetCD()
+	return self.CD or PATH_SEPARATOR
+end
+
+-- Changes the current directory
+function Directory:SetCD(directory)
+	assert(RunService:IsClient(), "SetCD may only be used from the client.")
+
+	local cd = self:GetCD()
+
+	-- Resolve absolute path, and don't set it if it hasn't changed
+	directory = self:ResolveAbsolutePathname(directory, cd)
+	if directory == cd then
+		return
+	end
+
+	self.CD = directory
+end
+
+-- Gets an instance by its pathname
+function Directory:GetInstance(path, rootInstance)
+	local fullPath = self:ResolveAbsolutePathname(path, self:GetCD())
+	local item = rootInstance or ROOT_INSTANCE
+	
+	assert(item, "GetInstance was passed an invalid root instance")
+
+	if fullPath == PATH_SEPARATOR then
+		return item
+	end
+	local segments = self:ParsePathname(fullPath)
+	local numSegments = #segments
+	for index, segment in ipairs(segments) do
+		-- Skip first segment since its an absolute path
+		if index == 1 then
+			continue
+		elseif index == numSegments then
+			if segment == "" then
+				break
+			end
+		end
+
+		item = item:FindFirstChild(segment)
+		-- Item doesn't exist, stop searching
+		if not item then
+			break
+		end
+	end
+	return item
+end
+
+-- Parses a pathname into its segments
+function Directory:ParsePathname(pathname)
+	if pathname == "/" then
+		return {""}
+	end
+	return string.split(pathname, PATH_SEPARATOR)
+end
+
+-- Combines a list of path segments or names into a full path, resolving special path words
+function Directory:JoinPaths(...)
+	local argCount = select("#", ...)
+	local args = {...}
+
+	local combined = table.create(argCount)
+	for _, path in ipairs(args) do
+		if type(path) == "string" then
+			path = self:ParsePathname(path)
+		elseif type(path) ~= "table" then
+			error(string.format("JoinPaths expected arguments of type 'table' or 'string' but got type '%s'", type(path)), 2)
+		end
+
+		for _, segment in ipairs(path) do
+			table.insert(combined, segment)
+		end
+	end
+
+	local firstSegment = combined[1]
+	if firstSegment == HOME_WORD then
+		-- Replace the first segment with the home directory
+		table.remove(combined, 1)
+
+		local segments = Directory:ParsePathname(self:GetHomeDirectory())
+		for index, segment in ipairs(segments) do
+			table.insert(combined, index, segment)
+		end
+	elseif firstSegment == CD_WORD then
+		-- Replace the first segment with the current directory
+		table.remove(combined, 1)
+
+		local segments = Directory:ParsePathname(self:GetCD())
+		for index, segment in ipairs(segments) do
+			table.insert(combined, index, segment)
+		end
+	end
+
+	local combinedFinal = table.create(#combined)
+	for _, segment in ipairs(combined) do
+		if segment ~= CD_WORD then
+			if segment == PARENT_WORD then
+				table.remove(combinedFinal, #combinedFinal)
+			else
+				table.insert(combinedFinal, segment)
+			end
+		end
+	end
+	return table.concat(combinedFinal, PATH_SEPARATOR)
+end
+
+local roots = {
+	[""] = PATH_SEPARATOR,
+	[HOME_WORD] = HOME_WORD
+}
+
+-- Resolves an absolute path with the given base path which defaults to the cd
+function Directory:ResolveAbsolutePathname(path, basePath)
+	local segments = self:ParsePathname(path)
+
+	-- If the directory is prefixed with some kind of root folder we want to use that root folder instead of the cd
+	local root = roots[segments[1]]
+	if root then
+		table.remove(segments, 1)
+		basePath = self:ParsePathname(root)
+	end
+
+	-- Join the path at the base
+	local joined = self:JoinPaths(basePath or self:GetCD(), segments)
+	if string.sub(joined, 1, #PATH_SEPARATOR) ~= PATH_SEPARATOR then
+		joined = PATH_SEPARATOR .. joined
+	end
+	return joined
+end
+
+-- Gets the current home directory
+function Directory:GetHomeDirectory()
+	local homeStack = self.HomeStack
+	return homeStack[#homeStack] or (PATH_SEPARATOR .. CD_WORD)
+end
+
+-- Push/pop for home directories, can properly handle "sudo" behaviour where a user invokes stuff on the home folder of another user
+-- e.g. an emulation of sudo -u "fake-user"
+function Directory:PushHomeDirectory(path)
+	local homeStack = self.HomeStack
+	table.insert(homeStack, self:ResolveAbsolutePathname(path))
+end
+function Directory:PopHomeDirectory()
+	local homeStack = self.HomeStack
+	return table.remove(homeStack, #homeStack)
+end
+
+local directories = {}
+function Directory.new(player)
+	local existing = directories[player]
+	if existing then
+		return existing
+	end
+
+	local directory = setmetatable({
+		HomeStack = {}
+	}, Directory)
+
+	-- Push the player's character to their home directory
+	local character = player.Character
+	if character then
+		directory:PushHomeDirectory(
+			directory:ResolveAbsolutePathname(PATH_SEPARATOR .. string.gsub(character:GetFullName(), "%.", PATH_SEPARATOR))
+		)
+	end
+
+	directories[player] = directory
+	return directory
+end
+
+return Directory

--- a/Cmdr/Shared/Directory.lua
+++ b/Cmdr/Shared/Directory.lua
@@ -12,8 +12,15 @@ local PARENT_WORD = ".."
 local CD_WORD = "."
 local PATH_SEPARATOR = "/"
 
+Directory.HOME_WORD = HOME_WORD
+Directory.PARENT_WORD = PARENT_WORD
+Directory.CD_WORD = CD_WORD
+Directory.PATH_SEPARATOR = PATH_SEPARATOR
+
 -- Root instance
 local ROOT_INSTANCE = game
+
+Directory.ROOT_INSTANCE = ROOT_INSTANCE
 
 -- Gets the current directory
 function Directory:GetCD()

--- a/Cmdr/Shared/Directory.lua
+++ b/Cmdr/Shared/Directory.lua
@@ -166,6 +166,10 @@ end
 
 local directories = {}
 function Directory.new(player)
+	if not player then
+		return Directory
+	end
+
 	local existing = directories[player]
 	if existing then
 		return existing

--- a/Cmdr/init.lua
+++ b/Cmdr/init.lua
@@ -1,5 +1,6 @@
 local RunService = game:GetService("RunService")
 local Util = require(script.Shared:WaitForChild("Util"))
+local Directory = require(script.Shared:WaitForChild("Directory"))
 
 if RunService:IsServer() == false then
 	error("Cmdr server module is somehow running on a client!")
@@ -11,6 +12,7 @@ local Cmdr do
 		RemoteFunction = nil;
 		RemoteEvent = nil;
 		Util = Util;
+		Directory = Directory;
 		DefaultCommandsFolder = script.BuiltInCommands;
 	}, {
 		__index = function (self, k)


### PR DESCRIPTION
* Add `cd` and `ls` commands for navigating the instance tree and listing instances.
* Add global `Directory` utility module which handles states such as the current directory and home path.
  * Uses Unix path conventions (`~/` is home directory, `/`s as separators, case sensitive pathnames)
  * Tracks CDs uniquely for different players
* Implements `..` for the parent directory, properly accounts for `.` being the current directory, `/` is the root instance (game), `~` is the home directory (but only as a root path). Cmdr uses `.` as the default of a type which plays nicely (default is the CD)
  * Home directory for players is their character
* Add `CommandContext.Directory` which is the active directory object for the executor.
* Added `instance` and `pathname` types. The prior resolves to an `Instance` and the latter resolves to an absolute path.
  * Supports autocompletes
  * Type resolution will be desynced for the client and server due to a Cmdr limitation, a type has no way of knowing which player is parsing, so a type cannot parse properly on the server with respect to the player's CD and home path (TODO)

Closes #78