### PR TITLE
Fix error on invalid return value

### DIFF
--- a/Cmdr/Shared/Argument.lua
+++ b/Cmdr/Shared/Argument.lua
@@ -60,7 +60,7 @@ function Argument:GetDefaultAutocomplete()
 		return strings, options or {}
 	end
 
-	return {}
+	return {}, {}
 end
 
 --- Calls the transform function on this argument.


### PR DESCRIPTION
The code expects`GetDefaultAutocomplete` to return 2 values, but if `self.Type.Autocomplete` doesn't evaluate to a truthy condition, it will only return 1 value instead of 2.