### PR TITLE
Fix incorrect number of arguments passed to `AutoComplete`, `Validate` and `Parse` on using value operators like `**`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Added column logic to properly align text containing newlines
 - Fix a new error caused by `var` & `varSet` in places with DataStore access disabled. (#188)
 - Fix incorrect DataStore used by `var` and `varSet` commands.
+- Fix incorrect number of arguments passed to `AutoComplete`, `Validate` and `Parse` on using value operators like `**` and `.` (Types).
 
 # v1.8.4
 - Fix an error when using function arguments.

--- a/Cmdr/Shared/Argument.lua
+++ b/Cmdr/Shared/Argument.lua
@@ -54,9 +54,7 @@ end
 
 function Argument:GetDefaultAutocomplete()
 	if self.Type.Autocomplete then
-		local transformedEmpty = self:TransformSegment("")
-		local strings, options = self.Type.Autocomplete(transformedEmpty)
-
+		local strings, options = self.Type.Autocomplete(self:TransformSegment(""))
 		return strings, options or {}
 	end
 


### PR DESCRIPTION
In the `GetDefaultAutocomplete` method, only 1 return value from `Argument:TransformSegment` is accounted. So when the `Transform` function returns more than 1 value,  sometimes only the first value is passed to `Autocomplete`, `Validate` and `Parse`, and the rest are disregarded. 

This is currently happening with a custom type I've created in which the transform method returns more than 1 value, the  executor and the results from `Util.MakeFuzzyFinder(Players:GetPlayers())` which are later used in my `ValidateOnce`  method. However, errors occur because `ValidateOnce` is only passed the executor, and not the second value i.e `findPlayer(text)`.  This pull request fixes this issue easily with just a very small edit. 

**This issue happens when I try to use value operators like ** and . for this type**

```lua

local gamePlayerType = {
	Transform = function(text, executor)
		local findPlayer = Util.MakeFuzzyFinder(Players:GetPlayers())

		return executor, findPlayer(text)
	end,

	ValidateOnce = function(executor, players)
		local player = players[1]

		-- If the player was executing this command on themselves, we can allow that. The reason for this is
		-- that we can't handle command execution ambiguity.
		if player == executor or not player then
			return true
		end

		-- Get the player's admin level and if they are higher/equal to the
		-- executor's admin level, throw in an error:
		local playerAdminLevel = CmdrUtil.GetPlayerAdminLevel(player)
		local executorAdminLevel = CmdrUtil.GetPlayerAdminLevel(executor)

		return playerAdminLevel < executorAdminLevel,
			"Can't include this player as they're an admin higher or equal to you"
	end,

       ....
}
```

