### PR TITLE
Fix nil errors when using duration type

### DIFF
--- a/Cmdr/BuiltInTypes/Duration.lua
+++ b/Cmdr/BuiltInTypes/Duration.lua
@@ -93,6 +93,7 @@ local durationType = {
             local endingUnit = rawText:match("^.*-?%d+(%a+)%s?$")
             -- Assume there is a singular match at this point
             local fuzzyUnits = unitFinder(endingUnit)
+			if fuzzyUnits == nil or endingUnit == nil then return end
             -- List all possible fuzzy matches. This is for the Minutes/Months ambiguity case.
             returnTable = mapUnits(fuzzyUnits, rawText, lastNumber, #endingUnit + 1)
             -- Sort alphabetically in the Minutes/Months case, so Minutes are displayed on top.

--- a/Cmdr/CmdrClient/CmdrInterface/init.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/init.lua
@@ -66,8 +66,10 @@ return function (Cmdr)
 					options = options or {}
 					isPartial = options.IsPartial or false
 
-					for i, item in pairs(items) do
-						acItems[i] = {typedText, item}
+					if items ~= nil then
+						for i, item in pairs(items) do
+							acItems[i] = {typedText, item}
+						end
 					end
 				end
 

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -71,6 +71,7 @@ function Util.MakeFuzzyFinder(setOrContainer)
 		local results = {}
 
 		for i, name in pairs(names) do
+			if name == nil or text == nil then continue end
 			local value = instances and instances[i] or name
 
 			-- Continue on checking for non-exact matches...


### PR DESCRIPTION
Been having some "harmless" errors happening client-side whenever a Duration autocomplete command is typed in. {duration being the last argument}

This pull request aims to fix that. If you need to edit it to keep with your standards, then go ahead.