### PR TITLE
Add window height method

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -7,8 +7,9 @@ local Players = game:GetService("Players")
 local Player = Players.LocalPlayer
 
 local LINE_HEIGHT = 20
-local WINDOW_MAX_HEIGHT = 300
-local MOUSE_TOUCH_ENUM = {Enum.UserInputType.MouseButton1, Enum.UserInputType.MouseButton2, Enum.UserInputType.Touch}
+local MOUSE_TOUCH_ENUM = { Enum.UserInputType.MouseButton1, Enum.UserInputType.MouseButton2, Enum.UserInputType.Touch }
+
+local windowMaxHeight = 300
 
 --- Window handles the command bar GUI
 local Window = {
@@ -38,6 +39,11 @@ function Window:GetLabel()
 	return Entry.TextLabel.Text
 end
 
+function Window:UpdateMaxHeight(newMaxHeight)
+	windowMaxHeight = newMaxHeight
+	self:UpdateWindowHeight()
+end
+
 --- Recalculate the window height
 function Window:UpdateWindowHeight()
 	local windowHeight = LINE_HEIGHT
@@ -49,12 +55,11 @@ function Window:UpdateWindowHeight()
 	end
 
 	Gui.CanvasSize = UDim2.new(Gui.CanvasSize.X.Scale, Gui.CanvasSize.X.Offset, 0, windowHeight)
-	Gui.Size =
-		UDim2.new(
+	Gui.Size = UDim2.new(
 		Gui.Size.X.Scale,
 		Gui.Size.X.Offset,
 		0,
-		windowHeight > WINDOW_MAX_HEIGHT and WINDOW_MAX_HEIGHT or windowHeight
+		windowHeight > windowMaxHeight and windowMaxHeight or windowHeight
 	)
 
 	Gui.CanvasPosition = Vector2.new(0, math.clamp(windowHeight - 300, 0, math.huge))
@@ -71,8 +76,7 @@ function Window:AddLine(text, color)
 
 	local str = self.Cmdr.Util.EmulateTabstops(text or "nil", 8)
 	local line = Line:Clone()
-	line.Size =
-		UDim2.new(
+	line.Size = UDim2.new(
 		line.Size.X.Scale,
 		line.Size.X.Offset,
 		0,
@@ -180,16 +184,15 @@ function Window:TraverseHistory(delta)
 
 	if self.HistoryState == nil then
 		self.HistoryState = {
-			Position = #history + 1;
-			InitialText = self:GetEntryText();
+			Position = #history + 1,
+			InitialText = self:GetEntryText(),
 		}
 	end
 
 	self.HistoryState.Position = math.clamp(self.HistoryState.Position + delta, 1, #history + 1)
 
 	self:SetEntryText(
-		self.HistoryState.Position == #history + 1
-			and self.HistoryState.InitialText
+		self.HistoryState.Position == #history + 1 and self.HistoryState.InitialText
 			or history[self.HistoryState.Position]
 	)
 end
@@ -278,7 +281,8 @@ function Window:BeginInput(input, gameProcessed)
 				local lastArg = self.AutoComplete.Arg
 
 				newText = command.Alias
-				insertSpace = self.AutoComplete.NumArgs ~= #command.ArgumentDefinitions and self.AutoComplete.IsPartial == false
+				insertSpace = self.AutoComplete.NumArgs ~= #command.ArgumentDefinitions
+					and self.AutoComplete.IsPartial == false
 
 				local args = command.Arguments
 				for i = 1, #args do
@@ -319,29 +323,23 @@ function Window:BeginInput(input, gameProcessed)
 end
 
 -- Hook events
-Entry.TextBox.FocusLost:Connect(
-	function(submit)
-		return Window:LoseFocus(submit)
-	end
-)
+Entry.TextBox.FocusLost:Connect(function(submit)
+	return Window:LoseFocus(submit)
+end)
 
-UserInputService.InputBegan:Connect(
-	function(input, gameProcessed)
-		return Window:BeginInput(input, gameProcessed)
-	end
-)
+UserInputService.InputBegan:Connect(function(input, gameProcessed)
+	return Window:BeginInput(input, gameProcessed)
+end)
 
-Entry.TextBox:GetPropertyChangedSignal("Text"):Connect(
-	function()
-		if Entry.TextBox.Text:match("\t") then -- Eat \t
-			Entry.TextBox.Text = Entry.TextBox.Text:gsub("\t", "")
-			return
-		end
-		if Window.OnTextChanged then
-			return Window.OnTextChanged(Entry.TextBox.Text)
-		end
+Entry.TextBox:GetPropertyChangedSignal("Text"):Connect(function()
+	if Entry.TextBox.Text:match("\t") then -- Eat \t
+		Entry.TextBox.Text = Entry.TextBox.Text:gsub("\t", "")
+		return
 	end
-)
+	if Window.OnTextChanged then
+		return Window.OnTextChanged(Entry.TextBox.Text)
+	end
+end)
 
 Gui.ChildAdded:Connect(Window.UpdateWindowHeight)
 

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -6,33 +6,37 @@ local Shared = script:WaitForChild("Shared")
 local Util = require(Shared:WaitForChild("Util"))
 
 if RunService:IsClient() == false then
-	error("Server scripts cannot require the client library. Please require the server library to use Cmdr in your own code.")
+	error(
+		"Server scripts cannot require the client library. Please require the server library to use Cmdr in your own code."
+	)
 end
 
-local Cmdr do
+local Cmdr
+do
 	Cmdr = setmetatable({
-		ReplicatedRoot = script;
-		RemoteFunction = script:WaitForChild("CmdrFunction");
-		RemoteEvent = script:WaitForChild("CmdrEvent");
-		ActivationKeys = {[Enum.KeyCode.F2] = true};
-		Enabled = true;
-		MashToEnable = false;
-		ActivationUnlocksMouse = false;
-		HideOnLostFocus = true;
-		PlaceName = "Cmdr";
-		Util = Util;
-		Events = {};
+		ReplicatedRoot = script,
+		RemoteFunction = script:WaitForChild("CmdrFunction"),
+		RemoteEvent = script:WaitForChild("CmdrEvent"),
+		ActivationKeys = { [Enum.KeyCode.F2] = true },
+		Enabled = true,
+		MashToEnable = false,
+		ActivationUnlocksMouse = false,
+		HideOnLostFocus = true,
+		PlaceName = "Cmdr",
+		Util = Util,
+		MaxWindowHeight = 300,
+		Events = {},
 	}, {
 		-- This sucks, and may be redone or removed
 		-- Proxies dispatch methods on to main Cmdr object
-		__index = function (self, k)
+		__index = function(self, k)
 			local r = self.Dispatcher[k]
 			if r and type(r) == "function" then
-				return function (_, ...)
+				return function(_, ...)
 					return r(self.Dispatcher, ...)
 				end
 			end
-		end
+		end,
 	})
 
 	Cmdr.Registry = require(Shared.Registry)(Cmdr)
@@ -46,28 +50,42 @@ end
 local Interface = require(script.CmdrInterface)(Cmdr)
 
 --- Sets a list of keyboard keys (Enum.KeyCode) that can be used to open the commands menu
-function Cmdr:SetActivationKeys (keysArray)
+function Cmdr:SetActivationKeys(keysArray)
 	self.ActivationKeys = Util.MakeDictionary(keysArray)
 end
 
+--- Sets the max window height of the interface
+function Cmdr:SetMaxWindowHeight(newMaxWindowHeight)
+	local camera = workspace:FindFirstChildWhichIsA("Camera")
+
+	if camera then
+		local ySize = camera.ViewportSize.Y
+		self.MaxWindowHeight = math.clamp(newMaxWindowHeight, 150, ySize - 25)
+	else
+		self.MaxWindowHeight = 300
+	end
+
+	Interface.Window:UpdateMaxHeight()
+end
+
 --- Sets the place name label on the interface
-function Cmdr:SetPlaceName (name)
+function Cmdr:SetPlaceName(name)
 	self.PlaceName = name
 	Interface.Window:UpdateLabel()
 end
 
 --- Sets whether or not the console is enabled
-function Cmdr:SetEnabled (enabled)
+function Cmdr:SetEnabled(enabled)
 	self.Enabled = enabled
 end
 
 --- Sets if activation will free the mouse.
-function Cmdr:SetActivationUnlocksMouse (enabled)
+function Cmdr:SetActivationUnlocksMouse(enabled)
 	self.ActivationUnlocksMouse = enabled
 end
 
 --- Shows Cmdr window
-function Cmdr:Show ()
+function Cmdr:Show()
 	if not self.Enabled then
 		return
 	end
@@ -76,12 +94,12 @@ function Cmdr:Show ()
 end
 
 --- Hides Cmdr window
-function Cmdr:Hide ()
+function Cmdr:Hide()
 	Interface.Window:Hide()
 end
 
 --- Toggles Cmdr window
-function Cmdr:Toggle ()
+function Cmdr:Toggle()
 	if not self.Enabled then
 		return self:Hide()
 	end


### PR DESCRIPTION
I noticed there was no way to increase the max height constant for the Cmdr command window. It's a negligible feature, but it'd be useful for developers who need a little more screen real estate for verbose return strings.

Didn't spend too long on this fork, so if there's any mistakes please let me know.