### PR TITLE
Output RichText

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -59,8 +59,12 @@ function Window:UpdateWindowHeight()
 end
 
 --- Add a line to the command bar
-function Window:AddLine(text, color)
+function Window:AddLine(text, options)
 	text = tostring(text)
+
+	if typeof(options) == "Color3" then
+		options = { Color = options }
+	end
 
 	if #text == 0 then
 		Window:UpdateWindowHeight()
@@ -82,7 +86,8 @@ function Window:AddLine(text, color)
 		).Y + (LINE_HEIGHT - line.TextSize)
 	)
 	line.Text = str
-	line.TextColor3 = color or line.TextColor3
+	line.TextColor3 = options.Color or line.TextColor3
+	line.RichText = options.RichText or false
 	line.Parent = Gui
 end
 

--- a/Cmdr/CreateGui.lua
+++ b/Cmdr/CreateGui.lua
@@ -33,7 +33,7 @@ return function ()
 	UIListLayout.SortOrder = Enum.SortOrder.LayoutOrder
 	UIListLayout.Parent = Frame
 
-	local Line = Instance.new("TextLabel")
+	local Line = Instance.new("TextBox")
 	Line.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
 	Line.BackgroundTransparency = 1
 	Line.Font = Enum.Font.Code
@@ -42,7 +42,8 @@ return function ()
 	Line.TextColor3 = Color3.fromRGB(255, 255, 255)
 	Line.TextSize = 14
 	Line.TextXAlignment = Enum.TextXAlignment.Left
-	Line.RichText = true
+	Line.ClearTextOnFocus = false
+	Line.TextEditable = false
 	Line.Parent = Frame
 
 	local UIPadding = Instance.new("UIPadding")

--- a/Cmdr/CreateGui.lua
+++ b/Cmdr/CreateGui.lua
@@ -33,7 +33,7 @@ return function ()
 	UIListLayout.SortOrder = Enum.SortOrder.LayoutOrder
 	UIListLayout.Parent = Frame
 
-	local Line = Instance.new("TextBox")
+	local Line = Instance.new("TextLabel")
 	Line.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
 	Line.BackgroundTransparency = 1
 	Line.Font = Enum.Font.Code
@@ -42,8 +42,7 @@ return function ()
 	Line.TextColor3 = Color3.fromRGB(255, 255, 255)
 	Line.TextSize = 14
 	Line.TextXAlignment = Enum.TextXAlignment.Left
-	Line.ClearTextOnFocus = false
-	Line.TextEditable = false
+	Line.RichText = true
 	Line.Parent = Frame
 
 	local UIPadding = Instance.new("UIPadding")


### PR DESCRIPTION
richtext enabled on output messages and changed "Line" to a textlabel since it wasn't being treated as a textbox

couldn't enable richtext on the entry line due to the way ui text rendering behaves
![image](https://user-images.githubusercontent.com/58125798/185603046-fa326a5e-0327-482a-8aae-9aa78877ef75.png)

Closes #157 