### PR TITLE
Custom Window Height

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -7,8 +7,9 @@ local Players = game:GetService("Players")
 local Player = Players.LocalPlayer
 
 local LINE_HEIGHT = 20
-local WINDOW_MAX_HEIGHT = 300
 local MOUSE_TOUCH_ENUM = {Enum.UserInputType.MouseButton1, Enum.UserInputType.MouseButton2, Enum.UserInputType.Touch}
+
+local windowMaxHeight = 300
 
 --- Window handles the command bar GUI
 local Window = {
@@ -25,6 +26,11 @@ local Line = Gui:WaitForChild("Line")
 local Entry = Gui:WaitForChild("Entry")
 
 Line.Parent = nil
+
+function Window:UpdateMaxHeight(newMaxHeight)
+	windowMaxHeight = newMaxHeight
+	self:UpdateWindowHeight()
+end
 
 --- Update the text entry label
 function Window:UpdateLabel()
@@ -52,7 +58,7 @@ function Window:UpdateWindowHeight()
 		Gui.Size.X.Scale,
 		Gui.Size.X.Offset,
 		0,
-		windowHeight > WINDOW_MAX_HEIGHT and WINDOW_MAX_HEIGHT or windowHeight
+		windowHeight > windowMaxHeight and windowMaxHeight or windowHeight
 	)
 
 	Gui.CanvasPosition = Vector2.new(0, math.clamp(windowHeight - 300, 0, math.huge))

--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -27,6 +27,7 @@ local Entry = Gui:WaitForChild("Entry")
 
 Line.Parent = nil
 
+--- Sets the max window height value and updates the current window
 function Window:UpdateMaxHeight(newMaxHeight)
 	windowMaxHeight = newMaxHeight
 	self:UpdateWindowHeight()

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -45,6 +45,20 @@ end
 
 local Interface = require(script.CmdrInterface)(Cmdr)
 
+--- Sets the max window height of the interface
+function Cmdr:SetMaxWindowHeight (newMaxWindowHeight)
+	local camera = workspace:FindFirstChildWhichIsA("Camera")
+
+	if camera then
+		local ySize = camera.ViewportSize.Y
+		self.MaxWindowHeight = math.clamp(newMaxWindowHeight, 150, ySize - 25)
+	else
+		self.MaxWindowHeight = 300
+	end
+
+	Interface.Window:UpdateMaxHeight()
+end
+
 --- Sets a list of keyboard keys (Enum.KeyCode) that can be used to open the commands menu
 function Cmdr:SetActivationKeys (keysArray)
 	self.ActivationKeys = Util.MakeDictionary(keysArray)

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -47,7 +47,7 @@ local Interface = require(script.CmdrInterface)(Cmdr)
 
 --- Sets the max window height of the interface
 function Cmdr:SetMaxWindowHeight (newMaxWindowHeight)
-	local camera = workspace:FindFirstChildWhichIsA("Camera")
+	local camera = workspace.CurrentCamera
 
 	if camera then
 		local ySize = camera.ViewportSize.Y


### PR DESCRIPTION
When working with Cmdr in my projects, I sometimes needed the Cmdr UI to use more vertical screen real estate so I could see verbose messages that were returned from my Cmdr commands.

I've added this in so we can now size the window's height to a height that works best for our individual use cases.

**_Thanks._**