### PR TITLE
Improve run-lines Functionality

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/runLines.lua
+++ b/Cmdr/BuiltInCommands/Utility/runLines.lua
@@ -12,7 +12,7 @@ return {
 		}
 	};
 
-	Run = function(context, text)
+	ClientRun = function(context, text)
 		if #text == 0 then
 			return ""
 		end

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -315,7 +315,7 @@ function Util.RunCommandString(dispatcher, commandString)
 
 	local output = ""
 	for i, command in ipairs(commands) do
-		local outputEncoded = output:gsub("%$", "\\x24")
+		local outputEncoded = output:gsub("%$", "\\x24"):gsub("%%","%%%%")
 		command = command:gsub("||", output:find("%s") and ("%q"):format(outputEncoded) or outputEncoded)
 
 		output = tostring(


### PR DESCRIPTION
Redo of #177

While working with Innovation Security, we discovered a couple of things with respect to `run-lines` when using `init-edit` and `init-run`:
- By default, it doesn't appear to work at all since it uses `Dispatcher:Run(...)`, which only works on the client, but is called by the server.
- `run-lines` does not work with client commands, like `alias`.
- `run-lines` throws an error if the input text contains a percent character anywhere.

This pull request attempts to address those problems by making `run-lines` run on the client instead of the server, and escape percent characters before being used with `gsub`.