### PR TITLE
Typo in Registry:RegisterType

### DIFF
--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -28,7 +28,7 @@ local Registry = {
 --- Registers a type in the system.
 -- name: The type Name. This must be unique.
 function Registry:RegisterType (name, typeObject)
-	if not name or not typeof(name) == "string" then
+	if not name or typeof(name) ~= "string" then
 		error("Invalid type name provided: nil")
 	end
 


### PR DESCRIPTION
`Registry:RegisterType` has a quick type check on its first line wherein the `name` parameter is verified to be non-nil and a string. However, the bool expression checking this has a typo...

```lua
not typeof(name) == "string"
```

...which is equivalent to...

```lua
(not typeof(name)) == "string"
```

...which does not properly perform this check. It always evaluates to false. The expression should be...

```lua
not (typeof(name) == "string") -- or more simply:
typeof(name) ~= "string"
```

The Roblox's Script Analysis window reports this as a [ComparisonPrecedence](https://luau-lang.org/lint#comparisonprecedence-28) lint. This PR corrects the expression to use `~=`, fixing the logic issue and the lint.