### PR TITLE
Mention Wally as a setup option in docs

### DIFF
--- a/docs/guide/Setup.md
+++ b/docs/guide/Setup.md
@@ -20,6 +20,12 @@ You can download the latest model file release from the [releases section](https
 
 Cmdr has no dependencies, so it can also be easily included as a Git submodule and synced in with the rest of your project with [Rojo](https://github.com/LPGhatguy/rojo). If you don't know how to do this already, then please see method 1 :)
 
+Cmdr is also available on Wally [here](https://wally.run/package/evaera/cmdr). 
+```toml
+[server-dependencies]
+cmdr = "evaera/cmdr@1.9.0"
+```
+
 ### Warning
 
 ::: warning DO NOT MODIFY SOURCE CODE TO CHANGE BEHAVIOR

--- a/docs/guide/Setup.md
+++ b/docs/guide/Setup.md
@@ -23,7 +23,7 @@ Cmdr has no dependencies, so it can also be easily included as a Git submodule a
 Cmdr is also available on Wally [here](https://wally.run/package/evaera/cmdr). 
 ```toml
 [server-dependencies]
-cmdr = "evaera/cmdr@1.9.0"
+Cmdr = "evaera/cmdr@1.9.0"
 ```
 
 ### Warning

--- a/docs/guide/Setup.md
+++ b/docs/guide/Setup.md
@@ -20,7 +20,9 @@ You can download the latest model file release from the [releases section](https
 
 Cmdr has no dependencies, so it can also be easily included as a Git submodule and synced in with the rest of your project with [Rojo](https://github.com/LPGhatguy/rojo). If you don't know how to do this already, then please see method 1 :)
 
-Cmdr is also available on Wally [here](https://wally.run/package/evaera/cmdr). 
+#### via Wally
+
+Cmdr is also available on Wally [here](https://wally.run/package/evaera/cmdr). You can install it by adding the following to your project's `wally.toml`. See Wally's [Manifest Format](https://github.com/UpliftGames/wally#manifest-format) for more info.
 ```toml
 [server-dependencies]
 Cmdr = "evaera/cmdr@1.9.0"


### PR DESCRIPTION
I didn't know that it was available on Wally, so it'd be helpful to mention for people already using it for their projects. Included under `server-dependencies` to emphasize it being installed under a server directory like ServerStorage