### PR TITLE
Remove RoStrap support

### DIFF
--- a/Cmdr/Initialize.lua
+++ b/Cmdr/Initialize.lua
@@ -15,14 +15,7 @@ return function (cmdr)
 	end
 
 	ReplicatedRoot = script.Parent.CmdrClient
-
-	if ReplicatedStorage:FindFirstChild("Resources") and
-		ReplicatedStorage.Resources:FindFirstChild("Libraries") then -- If using RoStrap
-		-- ReplicatedRoot.Name = "Cmdr"
-		ReplicatedRoot.Parent = ReplicatedStorage.Resources.Libraries
-	else
-		ReplicatedRoot.Parent = ReplicatedStorage
-	end
+	ReplicatedRoot.Parent = ReplicatedStorage
 
 	RemoteFunction = Create("RemoteFunction", "CmdrFunction")
 	RemoteEvent = Create("RemoteEvent", "CmdrEvent")

--- a/docs/guide/Setup.md
+++ b/docs/guide/Setup.md
@@ -6,12 +6,6 @@ title: Setup
 ### Installation
 Pick one of the below methods to install Cmdr:
 
-<!-- #### Recommended
-
-The easiest way to get started with Cmdr is to install the [RoStrap Roblox Studio plugin](https://www.roblox.com/library/725884332/RoStrap), open the RoStrap interface in a place, and then install "Cmdr". This will instantly download and build the newest version of Cmdr right from GitHub.
-
-![Installation](https://user-images.githubusercontent.com/2489210/45920094-b27c3f80-be6d-11e8-9105-f358140b5a13.png) -->
-
 #### Manual
 
 You can download the latest model file release from the [releases section](https://github.com/evaera/Cmdr/releases/latest), but this may not always be the most up to date version of Cmdr. You'll want to put this in a server directory, like ServerScriptService.

--- a/docs/guide/Setup.md
+++ b/docs/guide/Setup.md
@@ -26,19 +26,6 @@ There should be **no reason** to modify the source code of Cmdr (unless you are 
 
 You should create a folder to keep your commands inside, and then register them on the server. However, you only need to register commands and types on the server. There should be no need to modify the actual Cmdr library itself.
 
-:::: tabs
-<!-- ::: tab "Using RoStrap"
-```lua
--- This is a script you would create in ServerScriptService, for example.
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Resources = require(ReplicatedStorage:WaitForChild("Resources"))
-local Cmdr = Resources:LoadLibrary("Cmdr")
-
-Cmdr:RegisterDefaultCommands() -- This loads the default set of commands that Cmdr comes with. (Optional)
--- Cmdr:RegisterCommandsIn(script.Parent.CmdrCommands) -- Register commands from your own folder. (Optional)
-```
-::: -->
-::: tab ""
 ```lua
 -- This is a script you would create in ServerScriptService, for example.
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -47,8 +34,6 @@ local Cmdr = require(path.to.Cmdr)
 Cmdr:RegisterDefaultCommands() -- This loads the default set of commands that Cmdr comes with. (Optional)
 -- Cmdr:RegisterCommandsIn(script.Parent.CmdrCommands) -- Register commands from your own folder. (Optional)
 ```
-:::
-::::
 
 The Cmdr GUI will be inserted into StarterGui if it doesn't already exist. You can customize the GUI to your liking (changing colors, etc.) if you play the game, copy the GUI, stop the game, and then paste it in to StarterGui. Of course, this is completely optional.
 
@@ -60,21 +45,8 @@ You need to require Cmdr on the server *and* on the client for it to be fully lo
 
 From the client, you also need to require the CmdrClient module.
 
-<!--If not using RoStrap, then--> After the server code above runs, CmdrClient will be inserted into ReplicatedStorage automatically.
+After the server code above runs, CmdrClient will be inserted into ReplicatedStorage automatically.
 
-:::: tabs
-<!-- ::: tab "Using RoStrap"
-```lua
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Resources = require(ReplicatedStorage:WaitForChild("Resources"))
-local Cmdr = Resources:LoadLibrary("CmdrClient")
-
--- Configurable, and you can choose multiple keys
-Cmdr:SetActivationKeys({ Enum.KeyCode.F2 })
--- See below for the full API.
-```
-::: -->
-::: tab ""
 ```lua
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Cmdr = require(ReplicatedStorage:WaitForChild("CmdrClient"))
@@ -83,8 +55,6 @@ local Cmdr = require(ReplicatedStorage:WaitForChild("CmdrClient"))
 Cmdr:SetActivationKeys({ Enum.KeyCode.F2 })
 -- See below for the full API.
 ```
-:::
-::::
 
 <script>
   export default {


### PR DESCRIPTION
Currently, CmdrClient will parent itself in `ReplicatedStorage.Resources.Libraries` if there is an instance at that path.

This behaviour was originally implemented to support the RoStrap, which allow CmdrClient to be required via its own loader.

However, this behaviour is undocumented and given the generic names used, confusing. Developers rightly expect CmdrClient to appear under `ReplicatedStorage`.

Additionally, RoStrap is out of date and seems to no-longer be used in the community and [Cmdr with RoStrap appears to not even work](https://github.com/evaera/Cmdr/commit/0a2f29ab44a399d95f29b0558cd5220e8750863d).

This pull request:

- removes this behaviour
- removes the (commented out) references to RoStrap in the docs' Setup guide