### PR TITLE
Fix command bar being obscured by TextChatService

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -3,6 +3,7 @@
 local GuiService = game:GetService("GuiService")
 local UserInputService = game:GetService("UserInputService")
 local TextService = game:GetService("TextService")
+local TextChatService = game:GetService("TextChatService")
 local Players = game:GetService("Players")
 local Player = Players.LocalPlayer
 
@@ -82,6 +83,11 @@ function Window:SetVisible(visible)
 	Gui.Visible = visible
 
 	if visible then
+		self.PreviousChatWindowConfigurationEnabled = TextChatService.ChatWindowConfiguration.Enabled
+		self.PreviousChatInputBarConfigurationEnabled = TextChatService.ChatInputBarConfiguration.Enabled
+		TextChatService.ChatWindowConfiguration.Enabled = false
+		TextChatService.ChatInputBarConfiguration.Enabled = false
+		
 		Entry.TextBox:CaptureFocus()
 		self:SetEntryText("")
 
@@ -90,6 +96,11 @@ function Window:SetVisible(visible)
 			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 		end
 	else
+		TextChatService.ChatWindowConfiguration.Enabled = if self.PreviousChatWindowConfigurationEnabled ~= nil then 
+			self.PreviousChatWindowConfigurationEnabled else true
+		TextChatService.ChatInputBarConfiguration.Enabled = if self.PreviousChatInputBarConfigurationEnabled ~= nil then 
+			self.PreviousChatInputBarConfigurationEnabled else true
+		
 		Entry.TextBox:ReleaseFocus()
 		self.AutoComplete:Hide()
 


### PR DESCRIPTION
There is currently an issue with the new TextChatService where if you're using it instead of the old Lua chat, the chat window will show over the Cmdr bar since it's now living in CoreGui, making it impossible to read. This is the cleanest fix I can think of at the moment; I simply to toggle Enabled on the input bar and chat tray in Window.SetVisible. I have made this fork already in my own game and it seems to work well.