### PR TITLE
Add ArgumentOperatorAliases to Player types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.11.0
+
+- Add support for new Roblox CoreGui Chat
+- Add ArgumentOperatorAliases option to types which allows specifying short hands like "me", "others", "all", etc for any type
+
 # v1.10.0
 - Improve help command
 - Alias command now supports optional arguments

--- a/Cmdr/BuiltInTypes/Player.lua
+++ b/Cmdr/BuiltInTypes/Player.lua
@@ -23,6 +23,13 @@ local playerType = {
 	Default = function(player)
 		return player.Name
 	end;
+
+	ArgumentOperatorAliases = {
+		me = ".";
+		all = "*";
+		others = "**";
+		random = "?";
+	};
 }
 
 return function (cmdr)

--- a/Cmdr/BuiltInTypes/PlayerId.lua
+++ b/Cmdr/BuiltInTypes/PlayerId.lua
@@ -45,6 +45,13 @@ local playerIdType = {
 	Default = function(player)
 		return player.Name
 	end;
+
+	ArgumentOperatorAliases = {
+		me = ".";
+		all = "*";
+		others = "**";
+		random = "?";
+	};
 }
 
 return function (cmdr)

--- a/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
@@ -2,15 +2,14 @@
 local Players = game:GetService("Players")
 local Player = Players.LocalPlayer
 
-return function (Cmdr)
+return function(Cmdr)
 	local AutoComplete = {
-		Items = {};
-		ItemOptions = {};
-		SelectedItem = 0;
+		Items = {},
+		ItemOptions = {},
+		SelectedItem = 0,
 	}
 
 	local Util = Cmdr.Util
-	local Shorthands = Util.MakeDictionary({"me", "all", ".", "*", "others"})
 
 	local Gui = Player:WaitForChild("PlayerGui"):WaitForChild("Cmdr"):WaitForChild("Autocomplete")
 	local AutoItem = Gui:WaitForChild("TextButton")
@@ -25,15 +24,24 @@ return function (Cmdr)
 		textObj.Text = text or ""
 
 		if sizeFromContents then
-			textObj.Size = UDim2.new(0, Util.GetTextSize(text or "", textObj, Vector2.new(1000, 1000), 1, 0).X, obj.Size.Y.Scale, obj.Size.Y.Offset)
+			textObj.Size = UDim2.new(
+				0,
+				Util.GetTextSize(text or "", textObj, Vector2.new(1000, 1000), 1, 0).X,
+				obj.Size.Y.Scale,
+				obj.Size.Y.Offset
+			)
 		end
 	end
 
 	-- Update the info display (Name, type, and description) based on given options.
-	local function UpdateInfoDisplay (options)
+	local function UpdateInfoDisplay(options)
 		-- Update the objects' text and sizes
 		SetText(Title, Title.Field, options.name, true)
-		SetText(Title.Field.Type, Title.Field.Type, options.type and ": " .. options.type:sub(1, 1):upper() .. options.type:sub(2))
+		SetText(
+			Title.Field.Type,
+			Title.Field.Type,
+			options.type and ": " .. options.type:sub(1, 1):upper() .. options.type:sub(2)
+		)
 		SetText(Description, Description.Label, options.description)
 
 		Description.Label.TextColor3 = options.invalid and Color3.fromRGB(255, 73, 73) or Color3.fromRGB(255, 255, 255)
@@ -70,7 +78,7 @@ return function (Cmdr)
 	-- options.description?: The description for the currently active info box
 	-- options.invalid?: If true, description is shown in red.
 	-- options.isLast?: If true, auto complete won't keep going after this argument.
-	function AutoComplete:Show (items, options)
+	function AutoComplete:Show(items, options)
 		options = options or {}
 
 		-- Remove old options.
@@ -97,10 +105,6 @@ return function (Cmdr)
 			local leftText = item[1]
 			local rightText = item[2]
 
-			if Shorthands[leftText] then
-				leftText = rightText
-			end
-
 			local btn = AutoItem:Clone()
 			btn.Name = leftText .. rightText
 			btn.BackgroundTransparency = i == self.SelectedItem and 0.5 or 1
@@ -123,13 +127,14 @@ return function (Cmdr)
 		local text = Entry.TextBox.Text
 		local words = Util.SplitString(text)
 		if text:sub(#text, #text) == " " and not options.at then
-			words[#words+1] = "e"
+			words[#words + 1] = "e"
 		end
 		table.remove(words, #words)
 		local extra = (options.at and options.at or (#table.concat(words, " ") + 1)) * 7
 
 		-- Update the auto complete container
-		Gui.Position = UDim2.new(0, Entry.TextBox.AbsolutePosition.X - 10 + extra, 0, Entry.TextBox.AbsolutePosition.Y + 30)
+		Gui.Position =
+			UDim2.new(0, Entry.TextBox.AbsolutePosition.X - 10 + extra, 0, Entry.TextBox.AbsolutePosition.Y + 30)
 		Gui.Size = UDim2.new(0, autocompleteWidth, 0, Gui.UIListLayout.AbsoluteContentSize.Y)
 		Gui.Visible = true
 
@@ -138,7 +143,7 @@ return function (Cmdr)
 	end
 
 	--- Returns the selected item in the auto complete
-	function AutoComplete:GetSelectedItem ()
+	function AutoComplete:GetSelectedItem()
 		if Gui.Visible == false then
 			return nil
 		end
@@ -147,18 +152,20 @@ return function (Cmdr)
 	end
 
 	--- Hides the auto complete
-	function AutoComplete:Hide ()
+	function AutoComplete:Hide()
 		Gui.Visible = false
 	end
 
 	--- Returns if the menu is visible
-	function AutoComplete:IsVisible ()
+	function AutoComplete:IsVisible()
 		return Gui.Visible
 	end
 
 	--- Changes the user's item selection by the given delta
-	function AutoComplete:Select (delta)
-		if not Gui.Visible then return end
+	function AutoComplete:Select(delta)
+		if not Gui.Visible then
+			return
+		end
 
 		self.SelectedItem = self.SelectedItem + delta
 

--- a/Cmdr/Shared/Argument.lua
+++ b/Cmdr/Shared/Argument.lua
@@ -70,6 +70,9 @@ function Argument:Transform()
 	end
 
 	local rawValue = self.RawValue
+	if self.Type.ArgumentOperatorAliases then
+		rawValue = self.Type.ArgumentOperatorAliases[rawValue] or rawValue
+	end
 
 	if rawValue == "." and self.Type.Default then
 		rawValue = self.Type.Default(self.Executor) or ""

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -4,7 +4,7 @@ local Util = require(script.Parent.Util)
 
 --- The registry keeps track of all the commands and types that Cmdr knows about.
 local Registry = {
-	TypeMethods = Util.MakeDictionary({"Transform", "Validate", "Autocomplete", "Parse", "DisplayName", "Listable", "ValidateOnce", "Prefixes", "Default"});
+	TypeMethods = Util.MakeDictionary({"Transform", "Validate", "Autocomplete", "Parse", "DisplayName", "Listable", "ValidateOnce", "Prefixes", "Default", "ArgumentOperatorAliases"});
 	CommandMethods = Util.MakeDictionary({"Name", "Aliases", "AutoExec", "Description", "Args", "Run", "ClientRun", "Data", "Group"});
 	CommandArgProps = Util.MakeDictionary({"Name", "Type", "Description", "Optional", "Default"});
 	Types = {};

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -285,6 +285,7 @@ function Util.MakeListableType(type, override)
 		ValidateOnce = type.ValidateOnce,
 		Autocomplete = type.Autocomplete,
 		Default = type.Default,
+		ArgumentOperatorAliases = type.ArgumentOperatorAliases,
 		Parse = function(...)
 			return {type.Parse(...)}
 		end

--- a/docs/api/Registry.md
+++ b/docs/api/Registry.md
@@ -92,6 +92,9 @@ docs:
             If you set the optional key `Listable` to `true` in your table, this will tell Cmdr that comma-separated lists are allowed for this type. Cmdr will automatically split the list and parse each segment through your Transform, Validate, Autocomplete, and Parse functions individually, so you don't have to change the logic of your Type at all.
 
             The only limitation is that your Parse function **must return a table**. The tables from each individual segment's Parse will be merged into one table at the end of the parse step. The uniqueness of values is ensured upon merging, so even if the user lists the same value several times, it will only appear once in the final table.
+        ArgumentOperatorAliases:
+          desc: "Table containing a map from an alias to the equivalent argument value operator (., *, ?, etc.) This is used for aliases like \"all\", \"others\", \"me\" for specific types."
+          type: "{[string]: string}"
 
     - name: CommandArgument
       kind: interface


### PR DESCRIPTION
Allows you to use "me", "all", "others" and "random" as an argument shorthand for Player and PlayerId types. 

Doesn't prevent you from using the default shorthands.

<img width="1025" alt="image" src="https://github.com/evaera/Cmdr/assets/30080152/e7acaa2b-9be2-43c5-ac9c-7426dd840cd3">
<img width="982" alt="image" src="https://github.com/evaera/Cmdr/assets/30080152/75871c9d-9e0e-4364-8aed-96d9a105983c">
<img width="967" alt="image" src="https://github.com/evaera/Cmdr/assets/30080152/b56890b1-7ad2-4969-9141-ef59b0578ae2">
<img width="983" alt="image" src="https://github.com/evaera/Cmdr/assets/30080152/a0e18edd-c02c-4e40-b948-4860113a0dd4">
 