### PR TITLE
Implement auto scroll to the bottom of the canvas on user text input

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -323,6 +323,10 @@ UserInputService.InputBegan:Connect(function(input, gameProcessed)
 end)
 
 Entry.TextBox:GetPropertyChangedSignal("Text"):Connect(function()
+	if Window.Cmdr and Window.Cmdr.CanvasAutoScrollToBottom then
+		Gui.CanvasPosition = Vector2.new(0, Gui.AbsoluteCanvasSize.Y)
+	end
+
 	if Entry.TextBox.Text:match("\t") then -- Eat \t
 		Entry.TextBox.Text = Entry.TextBox.Text:gsub("\t", "")
 		return

--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -2,7 +2,6 @@
 -- luacheck: ignore 212
 local GuiService = game:GetService("GuiService")
 local UserInputService = game:GetService("UserInputService")
-local TextService = game:GetService("TextService")
 local TextChatService = game:GetService("TextChatService")
 local Players = game:GetService("Players")
 local Player = Players.LocalPlayer

--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -323,9 +323,7 @@ UserInputService.InputBegan:Connect(function(input, gameProcessed)
 end)
 
 Entry.TextBox:GetPropertyChangedSignal("Text"):Connect(function()
-	if Window.Cmdr and Window.Cmdr.CanvasAutoScrollToBottom then
-		Gui.CanvasPosition = Vector2.new(0, Gui.AbsoluteCanvasSize.Y)
-	end
+	Gui.CanvasPosition = Vector2.new(0, Gui.AbsoluteCanvasSize.Y)
 
 	if Entry.TextBox.Text:match("\t") then -- Eat \t
 		Entry.TextBox.Text = Entry.TextBox.Text:gsub("\t", "")

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -18,7 +18,7 @@ local Cmdr do
 		Enabled = true;
 		MashToEnable = false;
 		ActivationUnlocksMouse = false;
-		CanvasAutoScrollToBottom = false;
+		CanvasAutoScrollToBottom = true;
 		HideOnLostFocus = true;
 		PlaceName = "Cmdr";
 		Util = Util;

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -18,6 +18,7 @@ local Cmdr do
 		Enabled = true;
 		MashToEnable = false;
 		ActivationUnlocksMouse = false;
+		CanvasAutoScrollToBottom = false;
 		HideOnLostFocus = true;
 		PlaceName = "Cmdr";
 		Util = Util;
@@ -106,6 +107,11 @@ end
 --- Sets the handler for a certain event type
 function Cmdr:HandleEvent(name, callback)
 	self.Events[name] = callback
+end
+
+--- Sets the CanvasAutoScrollToBottom property to control automatic scrolling behavior
+function Cmdr:SetCanvasAutoScrollToBottom(isEnabled)
+	self.CanvasAutoScrollToBottom = isEnabled
 end
 
 -- Only register when we aren't in studio because don't want to overwrite what the server portion did

--- a/Cmdr/CmdrClient/init.lua
+++ b/Cmdr/CmdrClient/init.lua
@@ -18,7 +18,6 @@ local Cmdr do
 		Enabled = true;
 		MashToEnable = false;
 		ActivationUnlocksMouse = false;
-		CanvasAutoScrollToBottom = true;
 		HideOnLostFocus = true;
 		PlaceName = "Cmdr";
 		Util = Util;
@@ -107,11 +106,6 @@ end
 --- Sets the handler for a certain event type
 function Cmdr:HandleEvent(name, callback)
 	self.Events[name] = callback
-end
-
---- Sets the CanvasAutoScrollToBottom property to control automatic scrolling behavior
-function Cmdr:SetCanvasAutoScrollToBottom(isEnabled)
-	self.CanvasAutoScrollToBottom = isEnabled
 end
 
 -- Only register when we aren't in studio because don't want to overwrite what the server portion did


### PR DESCRIPTION
This makes the canvas auto scroll to the bottom on any text input.
On by default, call `Cmdr:CanvasAutoScrollToBottom()` with param `isEnabled` to set the behaviour

![image](https://github.com/evaera/Cmdr/assets/74055355/6a43c742-f1be-4efe-adb8-328a2d49962a)