### PR TITLE
Improve FuzzyFind/AutoComplete

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
@@ -108,8 +108,14 @@ return function(Cmdr)
 			local btn = AutoItem:Clone()
 			btn.Name = leftText .. rightText
 			btn.BackgroundTransparency = i == self.SelectedItem and 0.5 or 1
-			btn.Typed.Text = leftText
-			btn.Suggest.Text = string.rep(" ", #leftText) .. rightText:sub(#leftText + 1)
+
+			local start, stop = string.find(rightText:lower(), leftText:lower(), 1, true)
+			btn.Typed.Text = string.rep(" ", start - 1) .. leftText
+			btn.Suggest.Text = string.sub(rightText, 0, start - 1)
+				.. string.rep(" ", #leftText)
+				.. string.sub(rightText, stop + 1)
+
+
 			btn.Parent = Gui
 			btn.LayoutOrder = i
 

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -81,7 +81,7 @@ function Util.MakeFuzzyFinder(setOrContainer)
 				else
 					table.insert(results, 1, value)
 				end
-			elseif name:lower():sub(1, #text) == text:lower() then
+			elseif name:lower():find(text:lower(), 1, true) then
 				results[#results + 1] = value
 			end
 		end


### PR DESCRIPTION
I've found that it's frustrating not being able to have autocomplete when I type something that isn't the direct beginning of a final result. This is especially true when it comes to custom types and usernames. Being able to type `username` instead of `123xxx_username` is convenient/better/faster.

I've calculated the two strings required to display the autocomplete text in this PR like so:
```lua
"       user    " -- Typed.Text
"123xxx_    name" -- Suggest.Text
````

Combined it gives the same result as previously. It doesn't break previous usage.