### PR TITLE
init-edit and init-edit-global permission fix

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/var.lua
+++ b/Cmdr/BuiltInCommands/Utility/var.lua
@@ -2,7 +2,7 @@ return {
 	Name = "var";
 	Aliases = {};
 	Description = "Gets a stored variable.";
-	Group = "DefaultUtil";
+	Group = "DefaultAdmin";
 	AutoExec = {
 		"alias \"init-edit|Edit your initialization script\" edit ${var init} \\\\\n && var= init ||",
 		"alias \"init-edit-global|Edit the initialization script for all users\" edit ${var $init} \\\\\n && var= $init ||",

--- a/Cmdr/BuiltInCommands/Utility/varSet.lua
+++ b/Cmdr/BuiltInCommands/Utility/varSet.lua
@@ -2,7 +2,7 @@ return {
 	Name = "var=";
 	Aliases = {};
 	Description = "Sets a stored value.";
-	Group = "DefaultUtil";
+	Group = "DefaultAdmin";
 	Args = {
 		{
 			Type = "storedKey";


### PR DESCRIPTION
I don't really know much about lua and Cmdr, so I consider this a very good solution. Before, users could use init-edit-global to force administrators or other users to run commands. Once someone with permission to run the init command joined, it would be run, regardless if the original user had permissions to run it.