### PR TITLE
Utilising positiveInteger in BuiltInTypes and BuiltInCommands

### DIFF
--- a/Cmdr/BuiltInCommands/Admin/gotoPlace.lua
+++ b/Cmdr/BuiltInCommands/Admin/gotoPlace.lua
@@ -14,7 +14,7 @@ return {
 			Description = "The players you want to teleport";
 		},
 		{
-			Type = "positiveIntegers";
+			Type = "positiveInteger";
 			Name = "Place ID";
 			Description = "The Place ID you want to teleport to";
 		},

--- a/Cmdr/BuiltInCommands/Admin/gotoPlace.lua
+++ b/Cmdr/BuiltInCommands/Admin/gotoPlace.lua
@@ -14,7 +14,7 @@ return {
 			Description = "The players you want to teleport";
 		},
 		{
-			Type = "integer";
+			Type = "positiveIntegers";
 			Name = "Place ID";
 			Description = "The Place ID you want to teleport to";
 		},

--- a/Cmdr/BuiltInCommands/Utility/pick.lua
+++ b/Cmdr/BuiltInCommands/Utility/pick.lua
@@ -5,7 +5,7 @@ return {
 	Group = "DefaultUtil";
 	Args = {
 		{
-			Type = "integer";
+			Type = "nonNegativeInteger";
 			Name = "Index to pick";
 			Description = "The index of the item you want to pick";
 		},

--- a/Cmdr/BuiltInCommands/Utility/pick.lua
+++ b/Cmdr/BuiltInCommands/Utility/pick.lua
@@ -5,7 +5,7 @@ return {
 	Group = "DefaultUtil";
 	Args = {
 		{
-			Type = "nonNegativeInteger";
+			Type = "positiveInteger";
 			Name = "Index to pick";
 			Description = "The index of the item you want to pick";
 		},

--- a/Cmdr/BuiltInTypes/PlayerId.lua
+++ b/Cmdr/BuiltInTypes/PlayerId.lua
@@ -57,6 +57,6 @@ local playerIdType = {
 return function (cmdr)
 	cmdr:RegisterType("playerId", playerIdType)
 	cmdr:RegisterType("playerIds", Util.MakeListableType(playerIdType, {
-		Prefixes = "# integers"
+		Prefixes = "# positiveIntegers"
 	}))
 end

--- a/Cmdr/BuiltInTypes/PlayerId.lua
+++ b/Cmdr/BuiltInTypes/PlayerId.lua
@@ -22,7 +22,7 @@ end
 
 local playerIdType = {
 	DisplayName = "Full Player Name";
-	Prefixes = "# positiveIntegers";
+	Prefixes = "# positiveInteger";
 
 	Transform = function (text)
 		local findPlayer = Util.MakeFuzzyFinder(Players:GetPlayers())

--- a/Cmdr/BuiltInTypes/PlayerId.lua
+++ b/Cmdr/BuiltInTypes/PlayerId.lua
@@ -22,7 +22,7 @@ end
 
 local playerIdType = {
 	DisplayName = "Full Player Name";
-	Prefixes = "# integer";
+	Prefixes = "# positiveIntegers";
 
 	Transform = function (text)
 		local findPlayer = Util.MakeFuzzyFinder(Players:GetPlayers())


### PR DESCRIPTION
- Type `playerId` will now piggy back off of the `positiveInteger` type when utilising the `#` prefix;
- Command `pick` uses the `positiveInteger` type as arrays/dictionaries created from the `:split()` string function do not have any indexes lower than 0;
- Command `goToPlace` uses the `positiveInteger`