### PR TITLE
Fix AutoComplete Error When Type Returns Completely Different String

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/AutoComplete.lua
@@ -119,6 +119,11 @@ return function(Cmdr)
 			btn.BackgroundTransparency = i == self.SelectedItem and 0.5 or 1
 
 			local start, stop = string.find(rightText:lower(), leftText:lower(), 1, true)
+			if start == nil and stop == nil then
+				--start and stop are nil when the type returns an autocomplete result that is completely different (such as a custom alias hanlded within the type).
+				--One should never be nil without the other.
+				start, stop = 1, string.len(rightText)
+			end
 			btn.Typed.Text = string.rep(" ", start - 1) .. leftText
 			btn.Suggest.Text = string.sub(rightText, 0, start - 1)
 				.. string.rep(" ", #leftText)


### PR DESCRIPTION
In Nexus Admin (which uses Cmdr as a base), players are handled *very* differently to handle aliases and sets. When it autocompletes, it will return a list of players when an alias is typed in. When the original string is not part of what is returned by the autocomplete outside of aliases, say your autocomplete had an alias to turn `"creator"` into `"TheNexusAvenger"` for whatever reason, it causes an error in the autocomplete. This adds a check for when the `start` and `stop` variables become `nil` and adds default values when this happens.

Nexus Admin 2.7.2 uses this change in live games already.

Example meant to be run in a `LocalScript` that shows the issue. It creates a command `test` that will autocomplete with the string given unless it is exactly `preset`. Using `test preset` will show the error.
```lua
--This example is intended to run on the client.
assert(game:GetService("RunService"):IsClient(), "Example is expected to run on the client.")
local Cmdr = require(game:GetService("ReplicatedStorage"):WaitForChild("CmdrClient"))

--Create a type that returns different strings.
--Must have Autocomplete and a Transform or Autocomplete that converts a text such that the original text does not contain the next text.
Cmdr.Registry:RegisterType("testTypeWithTransform", {
	Transform = function(text)
		if text == "preset" then
			return "somethingElse"
		end
		return text
	end,
	Autocomplete = function(text)
		warn(text)
		return {text}
	end,
	Parse = function(value)
		return value
	end
})

--Create a command that uses this type.
Cmdr.Registry:RegisterCommandObject({
	Name = "test",
	Description = "Test command.",
	Group = "Test",
	Args = {
		{
			Type = "testTypeWithTransform",
			Name = "TestArg",
			Description = "Test argument. Use preset to show an error from autocomplete."
		},
	},
})
```