### PR TITLE
Cloned "Shared" folder instead of moving it. (#285)

### DIFF
--- a/Cmdr/Initialize.lua
+++ b/Cmdr/Initialize.lua
@@ -23,7 +23,7 @@ return function (cmdr)
 	Create("Folder", "Commands")
 	Create("Folder", "Types")
 
-	script.Parent.Shared.Parent = ReplicatedRoot
+	script.Parent.Shared:Clone().Parent = ReplicatedRoot
 
 	cmdr.ReplicatedRoot = ReplicatedRoot
 	cmdr.RemoteFunction = RemoteFunction


### PR DESCRIPTION
This is the fix I provide for the issue #285. Instead of moving the "Shared" folder to the "CmdrClient" ModuleScript I clone it to the aforementioned ModuleScript so the "Shared" folder's ModuleScripts can be used by the main "Cmdr" ModuleScript.