### PR TITLE
Add command-specific guard methods

### DIFF
--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -27,6 +27,7 @@ function Command.new (options)
 		Arguments = {}; -- A table which will hold ArgumentContexts for each argument
 		Data = options.Data; -- A special container for any additional data the command needs to collect from the client
 		Response = nil; -- Will be set at the very end when the command is run and a string is returned from the Run function.
+		Guards = options.Guards; -- A table of functions where the command will be interrupted if a string is returned
 	}
 
 	setmetatable(self, Command)
@@ -117,6 +118,11 @@ end
 function Command:Run ()
 	if self._Validated == nil then
 		error("Must validate a command before running.")
+	end
+
+	local guardMethods = self.Dispatcher:RunGuards(self)
+	if guardMethods then
+		return guardMethods
 	end
 
 	local beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)

--- a/Cmdr/Shared/Command.lua
+++ b/Cmdr/Shared/Command.lua
@@ -120,14 +120,14 @@ function Command:Run ()
 		error("Must validate a command before running.")
 	end
 
-	local guardMethods = self.Dispatcher:RunGuards(self)
-	if guardMethods then
-		return guardMethods
-	end
-
 	local beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
 	if beforeRunHook then
 		return beforeRunHook
+	end
+
+	local guardMethods = self.Dispatcher:RunGuards(self)
+	if guardMethods then
+		return guardMethods
 	end
 
 	if not IsServer and self.Object.Data and self.Data == nil then

--- a/Cmdr/Shared/Dispatcher.lua
+++ b/Cmdr/Shared/Dispatcher.lua
@@ -140,7 +140,7 @@ function Dispatcher:RunGuards(commandContext, ...)
 		local typeofGuardMethod = typeof(guardMethod)
 		assert(typeofGuardMethod == "function", `expected a function for a value in Command.Guards, got {typeofGuardMethod}`)
 
-		local guardResult = guardMethod(commandContext)
+		local guardResult = guardMethod(commandContext, ...)
 		if guardResult == nil then continue end
 
 		return tostring(guardResult)

--- a/Cmdr/Shared/Dispatcher.lua
+++ b/Cmdr/Shared/Dispatcher.lua
@@ -128,6 +128,25 @@ function Dispatcher:Run (...)
 	return command:Run()
 end
 
+--- Runs command-specific methods and returns nil for ok or a string for cancellation
+function Dispatcher:RunGuards(commandContext, ...)
+	local guardMethods = commandContext.Object.Guards
+	if guardMethods == nil then return end
+
+	local typeofGuardMethods = typeof(guardMethods)
+	assert(typeofGuardMethods == "table", `expected a table for Command.Guards, got {typeofGuardMethods}`)
+
+	for _, guardMethod in pairs(guardMethods) do
+		local typeofGuardMethod = typeof(guardMethod)
+		assert(typeofGuardMethod == "function", `expected a function for a value in Command.Guards, got {typeofGuardMethod}`)
+
+		local guardResult = guardMethod(self)
+		if guardResult == nil then continue end
+
+		return tostring(guardResult)
+	end
+end
+
 --- Runs hooks matching name and returns nil for ok or a string for cancellation
 function Dispatcher:RunHooks(hookName, commandContext, ...)
 	if not self.Registry.Hooks[hookName] then

--- a/Cmdr/Shared/Dispatcher.lua
+++ b/Cmdr/Shared/Dispatcher.lua
@@ -140,7 +140,7 @@ function Dispatcher:RunGuards(commandContext, ...)
 		local typeofGuardMethod = typeof(guardMethod)
 		assert(typeofGuardMethod == "function", `expected a function for a value in Command.Guards, got {typeofGuardMethod}`)
 
-		local guardResult = guardMethod(self)
+		local guardResult = guardMethod(commandContext)
 		if guardResult == nil then continue end
 
 		return tostring(guardResult)

--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -5,7 +5,7 @@ local Util = require(script.Parent.Util)
 --- The registry keeps track of all the commands and types that Cmdr knows about.
 local Registry = {
 	TypeMethods = Util.MakeDictionary({"Transform", "Validate", "Autocomplete", "Parse", "DisplayName", "Listable", "ValidateOnce", "Prefixes", "Default", "ArgumentOperatorAliases"});
-	CommandMethods = Util.MakeDictionary({"Name", "Aliases", "AutoExec", "Description", "Args", "Run", "ClientRun", "Data", "Group"});
+	CommandMethods = Util.MakeDictionary({"Name", "Aliases", "AutoExec", "Description", "Args", "Run", "ClientRun", "Data", "Group", "Guards"});
 	CommandArgProps = Util.MakeDictionary({"Name", "Type", "Description", "Optional", "Default"});
 	Types = {};
 	TypeAliases = {};


### PR DESCRIPTION
Closes #86 

- Guard methods are checked before hooks.

- When a guard method is called, the first parameter is the command context.

- The dispatcher also supports sending additional parameters as varargs (similar to hooks), though this is not used in standard command execution.

- If the guard method returns a non-nil value, the command will be interrupted and the value printed to the window.

**Example usage:**
```
return {
	-- <insert command object here with name, aliases, description, etc.>

	Guards = {
		function(self)
			if math.random(1,3) == 2 then
				return "You are unlucky!"
			end
		end;
		function(self)
			return if self.Executor.UserId ~= 92658764 then "You are not allowed to do this!" else nil
		end;
	};
}
```