### PR TITLE
Change built-in commands to use `ClientRun` over `Run`

### DIFF
--- a/Cmdr/BuiltInCommands/Debug/version.lua
+++ b/Cmdr/BuiltInCommands/Debug/version.lua
@@ -6,7 +6,7 @@ return {
 	Description = "Shows the current version of Cmdr",
 	Group = "DefaultDebug",
 
-	Run = function()
+	ClientRun = function()
 		return ("Cmdr Version %s"):format(version)
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/echo.lua
+++ b/Cmdr/BuiltInCommands/Utility/echo.lua
@@ -11,7 +11,7 @@ return {
 		},
 	},
 
-	Run = function(_, text)
+	ClientRun = function(_, text)
 		return text
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/jsonArrayEncode.lua
+++ b/Cmdr/BuiltInCommands/Utility/jsonArrayEncode.lua
@@ -13,7 +13,7 @@ return {
 		},
 	},
 
-	Run = function(_, text)
+	ClientRun = function(_, text)
 		return HttpService:JSONEncode(text:split(","))
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/len.lua
+++ b/Cmdr/BuiltInCommands/Utility/len.lua
@@ -11,7 +11,7 @@ return {
 		},
 	},
 
-	Run = function(_, list)
+	ClientRun = function(_, list)
 		return #(list:split(","))
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/pick.lua
+++ b/Cmdr/BuiltInCommands/Utility/pick.lua
@@ -16,7 +16,7 @@ return {
 		},
 	},
 
-	Run = function(_, index, list)
+	ClientRun = function(_, index, list)
 		return list:split(",")[index] or ""
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/rand.lua
+++ b/Cmdr/BuiltInCommands/Utility/rand.lua
@@ -17,7 +17,7 @@ return {
 		},
 	},
 
-	Run = function(_, min, max)
+	ClientRun = function(_, min, max)
 		return tostring(max and math.random(min, max) or math.random(min))
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/replace.lua
+++ b/Cmdr/BuiltInCommands/Utility/replace.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 
-	Run = function(_, haystack, needle, replacement)
+	ClientRun = function(_, haystack, needle, replacement)
 		return haystack:gsub(needle, replacement)
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/resolve.lua
+++ b/Cmdr/BuiltInCommands/Utility/resolve.lua
@@ -26,7 +26,7 @@ return {
 		end,
 	},
 
-	Run = function(context)
+	ClientRun = function(context)
 		return table.concat(context:GetArgument(2).RawSegments, ",")
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/run.lua
+++ b/Cmdr/BuiltInCommands/Utility/run.lua
@@ -14,7 +14,7 @@ return {
 		},
 	},
 
-	Run = function(context, commandString)
+	ClientRun = function(context, commandString)
 		return context.Cmdr.Util.RunCommandString(context.Dispatcher, commandString)
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/runif.lua
+++ b/Cmdr/BuiltInCommands/Utility/runif.lua
@@ -35,7 +35,7 @@ return {
 		},
 	},
 
-	Run = function(context, condition, arg, testAgainst, command)
+	ClientRun = function(context, condition, arg, testAgainst, command)
 		local conditionFunc = conditions[condition]
 
 		if not conditionFunc then

--- a/Cmdr/Shared/Util.lua
+++ b/Cmdr/Shared/Util.lua
@@ -423,7 +423,7 @@ function Util.SubstituteArgs(str, replace): string
 end
 
 --[=[
-	Creates an alias command
+	Creates an alias command, should only be used on the client.
 	@return CommandDefinition
 ]=]
 function Util.MakeAliasCommand(name: string, commandString: string)
@@ -465,7 +465,7 @@ function Util.MakeAliasCommand(name: string, commandString: string)
 		Description = `<Alias> {commandDescription or commandString}`,
 		Group = "UserAlias",
 		Args = args,
-		Run = function(context)
+		ClientRun = function(context)
 			return Util.RunCommandString(context.Dispatcher, Util.SubstituteArgs(commandString, context.RawArguments))
 		end,
 	}


### PR DESCRIPTION
`ClientRun` has been preferred to `Run` for some time now. While most built-in commands are now using `ClientRun`, some are still using the legacy `Run` definition.

It's important that our built-in commands are good examples and therefore shouldn't exhibit deprecated or unadvised behaviour. Accordingly, this pull request changes those remaining built-in commands to use the new `ClientRun` function.