### PR TITLE
Add container argument to RegisterHooksIn

### DIFF
--- a/Cmdr/Shared/Registry.lua
+++ b/Cmdr/Shared/Registry.lua
@@ -266,6 +266,7 @@ end
 	Registers all hooks from within a container on both the server and client.
 	If you want to add a hook only on the server or client – e.g. for logging – then you should use the Register.RegisterHook method instead.
 
+	@param container Instance
 	@server
 	@within Registry
 ]=]


### PR DESCRIPTION
Adds a `container` argument to RegisterHooksIn. Had to manually add a `@param` so this may be a Moonwave limitation, as RegisterHooksIn is defined as RegisterTypesIn.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [X] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [X] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

