### PR TITLE
Added support for both LegacyChatService and TextChatService in regards to player targetted binds

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/bind.lua
+++ b/Cmdr/BuiltInCommands/Utility/bind.lua
@@ -1,4 +1,5 @@
 local UserInputService = game:GetService("UserInputService")
+local TextChatService = game:GetService("TextChatService")
 
 return {
 	Name = "bind",
@@ -52,17 +53,23 @@ return {
 		elseif bindType == "bindableResource" then
 			return "Unimplemented..."
 		elseif bindType == "player" then
-			binds[bind] = bind.Chatted:Connect(function(message)
+			local function RunCommand(message)
 				local args = { message }
-				local chatCommand = context.Cmdr.Util.RunEmbeddedCommands(
-					context.Dispatcher,
-					context.Cmdr.Util.SubstituteArgs(command, args)
-				)
-				context:Reply(
-					("%s $ %s : %s"):format(bind.Name, chatCommand, context.Dispatcher:EvaluateAndRun(chatCommand)),
-					Color3.fromRGB(244, 92, 66)
-				)
-			end)
+				local chatCommand = context.Cmdr.Util.RunEmbeddedCommands(context.Dispatcher, context.Cmdr.Util.SubstituteArgs(command, args))
+				context:Reply(("%s $ %s : %s"):format(
+					bind.Name,
+					chatCommand,
+					context.Dispatcher:EvaluateAndRun(chatCommand)
+					), Color3.fromRGB(244, 92, 66))
+			end
+			
+			if TextChatService.ChatVersion == Enum.ChatVersion.LegacyChatService then
+				binds[bind] = bind.Chatted:Connect(RunCommand)
+			else
+				binds[bind] = TextChatService.SendingMessage:Connect(function(message)
+					RunCommand(message.Text)
+				end)
+			end
 		end
 
 		return "Bound command to input."


### PR DESCRIPTION
This pull request adds support for both LegacyChatService and TextChatService in regards to player targetted binds. By default newly created games utilise TextChatService now and having this on doesn't support the `.Chatted` player event so the bind functionality therefore needs to be updated to dynamically support both.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

