### PR TITLE
Replace window label string concatenation with interpolation

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -26,7 +26,7 @@ Line.Parent = nil
 
 -- Update the text entry label
 function Window:UpdateLabel()
-	Entry.TextLabel.Text = Player.Name .. "@" .. self.Cmdr.PlaceName .. "$"
+	Entry.TextLabel.Text = `{Player.Name}@{self.Cmdr.PlaceName}$`
 end
 
 -- Get the text entry label


### PR DESCRIPTION
More aesthetically pleasing and easier to read over the former concatenation

**Declarations**:

- [X] I declare that this contribution was created in whole or in part by me.
- [X] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [X] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.