### PR TITLE
Help Command - Inline Types

### DIFF
--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -17,7 +17,6 @@ Tips
 
 return {
 	Name = "help",
-	Aliases = { "cmds", "commands" },
 	Description = "Displays a list of all commands, or inspects one command.",
 	Group = "Help",
 	Args = {
@@ -36,22 +35,17 @@ return {
 			if command.Aliases and #command.Aliases > 0 then
 				context:Reply(`Aliases: {table.concat(command.Aliases, ", ")}`, Color3.fromRGB(230, 230, 230))
 			end
-			if command.Description then
-				context:Reply(`Description: {command.Description}`, Color3.fromRGB(230, 230, 230))
-			end
-			if command.Group then
-				context:Reply(`Group: {command.Group}`, Color3.fromRGB(230, 230, 230))
-			end
-			if command.Args then
-				for i, arg in ipairs(command.Args) do
-					if type(arg) == "function" then
-						arg = arg(context)
-					end
-
-					context:Reply(
-						`{arg.Name}{if arg.Optional == true then "?" else ""}: {arg.Type} - {arg.Description}`
-					)
+			context:Reply(command.Description, Color3.fromRGB(230, 230, 230))
+			for i, arg in ipairs(command.Args) do
+				if type(arg) == "function" then
+					arg = arg(arg)
 				end
+
+				context:Reply(
+					`{arg.Name}{if arg.Optional then "?" else ""}: {if type(arg.Type) == "string"
+						then arg.Type
+						else arg.Type.DisplayName} - {arg.Description}`
+				)
 			end
 		else
 			context:Reply(ARGUMENT_SHORTHANDS)
@@ -63,10 +57,10 @@ return {
 			end)
 			local lastGroup
 			for _, command in ipairs(commands) do
-				local group = command.Group or "No Group"
-				if lastGroup ~= group then
-					context:Reply(`\n{group}\n{string.rep("-", #group)}`)
-					lastGroup = group
+				command.Group = command.Group or "No Group"
+				if lastGroup ~= command.Group then
+					context:Reply(`\n{command.Group}\n{string.rep("-", #command.Group)}`)
+					lastGroup = command.Group
 				end
 				context:Reply(if command.Description then `{command.Name} - {command.Description}` else command.Name)
 			end

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -44,11 +44,11 @@ return {
 			end
 			if command.Args then
 				for i, arg in ipairs(command.Args) do
-					context:Reply(
-						`#{i} {if type(arg) == "table"
-							then `{arg.Name}{if arg.Optional == true then "?" else ""}: {arg.Type} - {arg.Description}`
-							else "Unknown (inline argument)"}`
-					)
+					if type(arg) == "function" then
+						arg = arg(context)
+					end
+					
+					context:Reply(`{arg.Name}{if arg.Optional == true then "?" else ""}: {arg.Type} - {arg.Description}`)
 				end
 			end
 		else

--- a/Cmdr/BuiltInCommands/help.lua
+++ b/Cmdr/BuiltInCommands/help.lua
@@ -47,8 +47,10 @@ return {
 					if type(arg) == "function" then
 						arg = arg(context)
 					end
-					
-					context:Reply(`{arg.Name}{if arg.Optional == true then "?" else ""}: {arg.Type} - {arg.Description}`)
+
+					context:Reply(
+						`{arg.Name}{if arg.Optional == true then "?" else ""}: {arg.Type} - {arg.Description}`
+					)
 				end
 			end
 		else


### PR DESCRIPTION
Allow inline types to be shown on the help command

Currently, it will just send a message saying "Unknown (inline argument)" - this isn't particularly useful for people who didn't write the commands themselves.

Turns out that you can get it to convert into a regular argument if you just actually use the function and pass the context.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

