### PR TITLE
Refactor `rand` Command to Use Random Class

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/rand.lua
+++ b/Cmdr/BuiltInCommands/Utility/rand.lua
@@ -1,3 +1,5 @@
+local generator = Random.new()
+
 return {
 	Name = "rand",
 	Aliases = {},
@@ -17,7 +19,11 @@ return {
 		},
 	},
 
-	ClientRun = function(_, min, max)
-		return tostring(max and math.random(min, max) or math.random(min))
+	ClientRun = function(_, firstNumber, secondNumber)
+		return tostring(
+			if secondNumber
+				then generator:NextInteger(firstNumber, secondNumber)
+				else generator:NextInteger(1, firstNumber)
+		)
 	end,
 }


### PR DESCRIPTION
Fixes #329 by using `Random.new()` instance instead of `math.random()`. Also updates function parameter names to match command arguments and reduce ambiguity.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

