### PR TITLE
Update Window.lua

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -153,7 +153,9 @@ function Window:LoseFocus(submit)
 
 	if Gui.Visible and not GuiService.MenuIsOpen then
 		-- self:SetEntryText("")
-		Entry.TextBox:CaptureFocus()
+		if not UserInputService.TouchEnabled then
+			Entry.TextBox:CaptureFocus()
+		end
 	elseif GuiService.MenuIsOpen and Gui.Visible then
 		self:Hide()
 	end

--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -151,11 +151,9 @@ function Window:LoseFocus(submit)
 
 	self:ClearHistoryState()
 
-	if Gui.Visible and not GuiService.MenuIsOpen then
+	if Gui.Visible and not GuiService.MenuIsOpen and not UserInputService.TouchEnabled then
 		-- self:SetEntryText("")
-		if not UserInputService.TouchEnabled then
-			Entry.TextBox:CaptureFocus()
-		end
+		Entry.TextBox:CaptureFocus()
 	elseif GuiService.MenuIsOpen and Gui.Visible then
 		self:Hide()
 	end


### PR DESCRIPTION
This simple addition fixes an issue that causes the keyboard to completely break on mobile devices. [Streamable link](https://streamable.com/sctoqj)

The script before would cause :CaptureFocus() everytime the TextBox would lose focus, creating an infinite loop of the keyboard opening and closing extremely quickly (as shown in the video link above).

My fix to this is adding a check if the user is on mobile or not. If they are on mobile, it will stop `Entry.TextBox:CaptureFocus()` from being ran.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

