### PR TITLE
Support ChannelTabsConfiguration hiding

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.lua
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.lua
@@ -79,8 +79,10 @@ function Window:SetVisible(visible)
 	if visible then
 		self.PreviousChatWindowConfigurationEnabled = TextChatService.ChatWindowConfiguration.Enabled
 		self.PreviousChatInputBarConfigurationEnabled = TextChatService.ChatInputBarConfiguration.Enabled
+		self.PreviousChannelTabsConfigurationEnabled = TextChatService.ChannelTabsConfiguration.Enabled
 		TextChatService.ChatWindowConfiguration.Enabled = false
 		TextChatService.ChatInputBarConfiguration.Enabled = false
+		TextChatService.ChannelTabsConfiguration.Enabled = false
 
 		Entry.TextBox:CaptureFocus()
 		self:SetEntryText("")
@@ -96,6 +98,9 @@ function Window:SetVisible(visible)
 		TextChatService.ChatInputBarConfiguration.Enabled = if self.PreviousChatInputBarConfigurationEnabled
 				~= nil
 			then self.PreviousChatInputBarConfigurationEnabled
+			else true
+		TextChatService.ChannelTabsConfiguration.Enabled = if self.PreviousChannelTabsConfigurationEnabled ~= nil
+			then self.PreviousChannelTabsConfigurationEnabled
 			else true
 
 		Entry.TextBox:ReleaseFocus()


### PR DESCRIPTION
Makes [channel tabs](https://devforum.roblox.com/t/channel-tabs-ui-gradient-now-available-in-textchatservice/3249560) hide with the rest of the chat when the Cmdr interface is visible

Old
![image](https://github.com/user-attachments/assets/609cc40e-a293-42ae-b78d-3c8628e1a0f9)
New 
![image](https://github.com/user-attachments/assets/e549e080-dd31-4832-b366-b7d711f8f828)


**Declarations**:

- [X] I declare that this contribution was created in whole or in part by me.
- [X] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [X] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

