### PR TITLE
Migrate to TextChatService:CanUsersChatAsync

### DIFF
--- a/Cmdr/BuiltInCommands/Admin/announceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/announceServer.lua
@@ -1,12 +1,12 @@
+local TextChatService = game:GetService("TextChatService")
 local TextService = game:GetService("TextService")
 local Players = game:GetService("Players")
-local Chat = game:GetService("Chat")
 
 return function(context, text)
 	local filterResult = TextService:FilterStringAsync(text, context.Executor.UserId, Enum.TextFilterContext.PublicChat)
 
 	for _, player in ipairs(Players:GetPlayers()) do
-		if Chat:CanUsersChatAsync(context.Executor.UserId, player.UserId) then
+		if TextChatService:CanUsersChatAsync(context.Executor.UserId, player.UserId) then
 			context:SendEvent(player, "Message", filterResult:GetChatForUserAsync(player.UserId), context.Executor)
 		end
 	end


### PR DESCRIPTION
Roblox wants developers to [migrate to using TextChatService](https://devforum.roblox.com/t/integrate-textchatservicecanusersdirectchatasync-or-textchannelsetdirectchatrequester-api-to-comply-with-settings/3255672).

This pull changes `Chat:CanUsersChatAsync` to `TextChatService:CanUsersChatAsync`.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

