### PR TITLE
Migrate announceServer and DefaultEventHandlers for TextChatService support

### DIFF
--- a/Cmdr/BuiltInCommands/Admin/announceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/announceServer.lua
@@ -1,13 +1,10 @@
 local TextChatService = game:GetService("TextChatService")
-local TextService = game:GetService("TextService")
 local Players = game:GetService("Players")
 
 return function(context, text)
-	local filterResult = TextService:FilterStringAsync(text, context.Executor.UserId, Enum.TextFilterContext.PublicChat)
-
 	for _, player in ipairs(Players:GetPlayers()) do
 		if TextChatService:CanUsersChatAsync(context.Executor.UserId, player.UserId) then
-			context:SendEvent(player, "Message", filterResult:GetChatForUserAsync(player.UserId), context.Executor)
+			context:SendEvent(player, "Message", text)
 		end
 	end
 

--- a/Cmdr/BuiltInCommands/Admin/announceServer.lua
+++ b/Cmdr/BuiltInCommands/Admin/announceServer.lua
@@ -1,12 +1,23 @@
 local TextChatService = game:GetService("TextChatService")
+local TextService = game:GetService("TextService")
 local Players = game:GetService("Players")
 
 return function(context, text)
-	for _, player in ipairs(Players:GetPlayers()) do
-		if TextChatService:CanUsersChatAsync(context.Executor.UserId, player.UserId) then
-			context:SendEvent(player, "Message", text)
+	local success, filterResult = pcall(function(...)
+		return TextService:FilterStringAsync(text, context.Executor.UserId, Enum.TextFilterContext.PublicChat)
+	end)
+
+	if success then
+		local filteredText = filterResult:GetNonChatStringForBroadcastAsync()
+
+		for _, player in ipairs(Players:GetPlayers()) do
+			if TextChatService:CanUsersChatAsync(context.Executor.UserId, player.UserId) then
+				context:SendEvent(player, "Message", filteredText)
+			end
 		end
+
+		return "Created announcement."
 	end
 
-	return "Created announcement."
+	return "Failed to filter announcement!"
 end

--- a/Cmdr/CmdrClient/DefaultEventHandlers.lua
+++ b/Cmdr/CmdrClient/DefaultEventHandlers.lua
@@ -1,19 +1,11 @@
-local StarterGui = game:GetService("StarterGui")
 local TextChatService = game:GetService("TextChatService")
 local Window = require(script.Parent.CmdrInterface.Window)
 
 return function(Cmdr)
 	Cmdr:HandleEvent("Message", function(text)
-		if TextChatService.ChatVersion == Enum.ChatVersion.LegacyChatService then
-			StarterGui:SetCore("ChatMakeSystemMessage", {
-				Text = ("[Announcement] %s"):format(text),
-				Color = Color3.fromRGB(249, 217, 56),
-			})
-		else
-			TextChatService.TextChannels.RBXSystem:DisplaySystemMessage(
-				`<font color="rgb(249, 217, 56)">[Announcement] {text}</font>`
-			)
-		end
+		TextChatService.TextChannels.RBXSystem:DisplaySystemMessage(
+			`<font color="rgb(249, 217, 56)">[Announcement] {text}</font>`
+		)
 	end)
 
 	Cmdr:HandleEvent("AddLine", function(...)


### PR DESCRIPTION
Update announceServer to filter using `GetNonChatStringForBroadcastAsync()` and include proper error handling. Additionally, update DefaultEventHandlers to remove support for outdated LegacyChat.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

