### PR TITLE
Pass argument values to Command:GetData

### DIFF
--- a/Cmdr/Shared/Command.luau
+++ b/Cmdr/Shared/Command.luau
@@ -192,7 +192,8 @@ function Command:GetData()
 	end
 
 	if self.Object.Data and not IsServer then
-		self.Data = self.Object.Data(self)
+		local values, length = self:GatherArgumentValues()
+		self.Data = self.Object.Data(self, unpack(values, 1, length))
 	end
 
 	return self.Data


### PR DESCRIPTION
## Summary
- Pass parsed command argument values into Command:GetData() when computing command data lazily.
- Match the existing Command:Run() path, which already calls Object.Data(self, unpack(values, 1, length)).

## Why
Command:GetData() is documented as the reliable way to access command data, but when it computes Data itself it currently calls Object.Data(self) without the parsed argument values. Commands whose Data function depends on command arguments can behave differently depending on whether data was already populated by Run().

## Testing
- Not run locally; this is a small consistency fix matching the existing Run() data path.
