### PR TITLE
add sorting to FuzzyFinder

### DIFF
--- a/Cmdr/Shared/Util.luau
+++ b/Cmdr/Shared/Util.luau
@@ -86,6 +86,7 @@ function Util.MakeFuzzyFinder(setOrContainer: any): (string, boolean?, boolean?)
 
 	-- Searches the set (checking exact matches first)
 	return function(text: string, returnFirst: boolean?, matchStart: boolean?)
+		local resultsPriority = {}
 		local results = {}
 
 		for i, name in pairs(names) do
@@ -97,16 +98,32 @@ function Util.MakeFuzzyFinder(setOrContainer: any): (string, boolean?, boolean?)
 				if returnFirst then
 					return value
 				else
-					table.insert(results, 1, value)
+					results[#results + 1] = value
+					resultsPriority[value] = 0
 				end
 			elseif matchStart then
 				if name:lower():sub(1, #text) == text:lower() then
 					results[#results + 1] = value
+					resultsPriority[value] = 1
 				end
-			elseif name:lower():find(text:lower(), 1, true) then
-				results[#results + 1] = value
+			else
+				local startingIndex = name:lower():find(text:lower(), 1, true)
+				if startingIndex then
+					results[#results + 1] = value
+					resultsPriority[value] = startingIndex
+				end
 			end
 		end
+
+		table.sort(results, function(a, b)
+			local aPriority = resultsPriority[a]
+			local bPriority = resultsPriority[b]
+			if aPriority ~= bPriority then
+				return aPriority < bPriority
+			end
+
+			return #a < #b
+		end)
 
 		if returnFirst then
 			return results[1]

--- a/Cmdr/Shared/Util.luau
+++ b/Cmdr/Shared/Util.luau
@@ -120,11 +120,21 @@ function Util.MakeFuzzyFinder(setOrContainer: any): (string, boolean?, boolean?)
 			local bPriority = resultsPriority[b]
 			if aPriority ~= bPriority then
 				return aPriority < bPriority
-			elseif type(a) == "string" and type(b) == "string" then
-				return #a < #b
-			end
+			else
+				local aStr = if typeof(a) == "string"
+					then a
+					elseif typeof(a) == "Instance" then a.Name
+					elseif typeof(a) == "table" and typeof(a.Name) == "string" then a.Name
+					else ""
 
-			return false
+				local bStr = if typeof(b) == "string"
+					then b
+					elseif typeof(b) == "Instance" then b.Name
+					elseif typeof(b) == "table" and typeof(b.Name) == "string" then b.Name
+					else ""
+
+				return #aStr < #bStr
+			end
 		end)
 
 		if returnFirst then

--- a/Cmdr/Shared/Util.luau
+++ b/Cmdr/Shared/Util.luau
@@ -120,9 +120,11 @@ function Util.MakeFuzzyFinder(setOrContainer: any): (string, boolean?, boolean?)
 			local bPriority = resultsPriority[b]
 			if aPriority ~= bPriority then
 				return aPriority < bPriority
+			elseif type(a) == "string" and type(b) == "string" then
+				return #a < #b
 			end
 
-			return #a < #b
+			return false
 		end)
 
 		if returnFirst then


### PR DESCRIPTION
add sorting to FuzzyFinder based on how early the key was found and value length; makes autocomplete way more reliable by prioritizing results which have the key at the start of the value

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

