### PR TITLE
feat(client): improve client API and GUI handling

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/clear.luau
+++ b/Cmdr/BuiltInCommands/Utility/clear.luau
@@ -1,23 +1,19 @@
-local Players = game:GetService("Players")
-
 return {
 	Name = "clear",
 	Aliases = {},
 	Description = "Clear all lines above the entry line of the Cmdr window.",
 	Group = "DefaultUtil",
 	Args = {},
-	ClientRun = function()
-		local player = Players.LocalPlayer
-		local gui = player:WaitForChild("PlayerGui"):WaitForChild("Cmdr")
-		local frame = gui:WaitForChild("Frame")
-
-		if gui and frame then
+	ClientRun = function(context)
+		local frame = context.Cmdr.Gui:WaitForChild("Frame")
+		if frame then
 			for _, child in pairs(frame:GetChildren()) do
 				if child.Name == "Line" and child:IsA("TextBox") then
 					child:Destroy()
 				end
 			end
 		end
+
 		return ""
 	end,
 }

--- a/Cmdr/BuiltInCommands/Utility/exit.luau
+++ b/Cmdr/BuiltInCommands/Utility/exit.luau
@@ -1,0 +1,11 @@
+return {
+	Name = "exit",
+	Aliases = {},
+	Description = "Exit the Cmdr window.",
+	Group = "DefaultUtil",
+	Args = {},
+	ClientRun = function(context)
+		context.Cmdr:Hide()
+		return ""
+	end,
+}

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -237,7 +237,7 @@ function Window:BeginInput(input, gameProcessed)
 		if self.Cmdr.MashToOpen then
 			if self:IsVisible() then
 				-- Prevent leftover mash presses from instantly closing Cmdr
-				if openedByMash and currentTime - lastPressTime <= 1 then
+				if openedByMash and currentTime - lastPressTime <= 0.5 then
 					return
 				end
 

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -111,6 +111,8 @@ function Window:SetVisible(visible)
 			self.PreviousMouseBehavior = nil
 		end
 	end
+
+	self.Cmdr.Toggled:Fire(visible)
 end
 
 -- Hides the command bar
@@ -161,9 +163,9 @@ function Window:LoseFocus(submit)
 	local text = Entry.TextBox.Text
 	self:ClearHistoryState()
 
-	if Gui.Visible and not GuiService.MenuIsOpen and not UserInputService.TouchEnabled then
+	if self:IsVisible() and not GuiService.MenuIsOpen and not UserInputService.TouchEnabled then
 		Entry.TextBox:CaptureFocus()
-	elseif GuiService.MenuIsOpen and Gui.Visible then
+	elseif self:IsVisible() and GuiService.MenuIsOpen then
 		self:Hide()
 	end
 
@@ -171,7 +173,7 @@ function Window:LoseFocus(submit)
 		HasLostFocus = true
 
 		if self.Valid then
-			task.wait()
+			--task.wait()
 			self:SetEntryText("")
 			self.ProcessEntry(text)
 		else
@@ -193,7 +195,6 @@ function Window:TraverseHistory(delta)
 	end
 
 	self.HistoryState.Position = math.clamp(self.HistoryState.Position + delta, 1, #history + 1)
-
 	self:SetEntryText(
 		self.HistoryState.Position == #history + 1 and self.HistoryState.InitialText
 			or history[self.HistoryState.Position]
@@ -212,8 +213,9 @@ function Window:SelectVertical(delta)
 	end
 end
 
-local lastPressTime = 0
 local pressCount = 0
+local lastPressTime = 0
+local lastOpenedTime = 0
 -- Handles user input when the box is focused
 function Window:BeginInput(input, gameProcessed)
 	if GuiService.MenuIsOpen then
@@ -225,25 +227,41 @@ function Window:BeginInput(input, gameProcessed)
 	end
 
 	if self.Cmdr.ActivationKeys[input.KeyCode] then -- Activate the command bar
-		if self.Cmdr.MashToEnable and not self.Cmdr.Enabled then
-			if tick() - lastPressTime < 1 then
-				if pressCount >= 5 then
-					self.Cmdr:SetEnabled(true)
-					return
-				else
-					pressCount = pressCount + 1
-				end
-			else
-				pressCount = 1
-			end
-			lastPressTime = tick()
-		elseif self.Cmdr.Enabled then
-			self:SetVisible(not self:IsVisible())
-			task.wait()
-			self:SetEntryText("")
+		if not self.Cmdr.Enabled then
+			return
+		end
 
-			if GuiService.MenuIsOpen then -- Special case for menu getting stuck open (roblox bug)
-				self:Hide()
+		local currentTime = os.clock()
+		if self.Cmdr.MashToOpen then
+			if self:IsVisible() then
+				-- Prevent leftover mash presses from instantly closing Cmdr
+				if currentTime - lastPressTime > 1 then
+					self:SetVisible(false)
+				end
+
+				return
+			end
+
+			-- Allow reopening without mashing for 10 seconds after opening
+			if currentTime - lastOpenedTime < 10 then
+				self:SetVisible(true)
+				lastOpenedTime = currentTime
+				return
+			end
+
+			pressCount = if currentTime - lastPressTime < 1 then pressCount + 1 else 1
+			lastPressTime = currentTime
+
+			if pressCount >= 5 then
+				self:SetVisible(true)
+				lastOpenedTime = currentTime
+				pressCount = 0
+			end
+		else
+			self:SetVisible(not self:IsVisible())
+
+			if self:IsVisible() then
+				lastOpenedTime = currentTime
 			end
 		end
 

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -242,7 +242,6 @@ function Window:BeginInput(input, gameProcessed)
 				end
 
 				self:SetVisible(false)
-				lastClosedTime = currentTime
 				openedByMash = false
 
 				return

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -73,6 +73,7 @@ function Window:IsVisible()
 end
 
 -- Sets the command bar visible or not
+local lastClosedTime = nil
 function Window:SetVisible(visible)
 	Gui.Visible = visible
 
@@ -92,6 +93,7 @@ function Window:SetVisible(visible)
 			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 		end
 	else
+		lastClosedTime = os.clock()
 		TextChatService.ChatWindowConfiguration.Enabled = if self.PreviousChatWindowConfigurationEnabled ~= nil
 			then self.PreviousChatWindowConfigurationEnabled
 			else true
@@ -213,10 +215,10 @@ function Window:SelectVertical(delta)
 	end
 end
 
+-- Handles user input when the box is focused
 local pressCount = 0
 local lastPressTime = 0
-local lastOpenedTime = 0
--- Handles user input when the box is focused
+local openedByMash = false
 function Window:BeginInput(input, gameProcessed)
 	if GuiService.MenuIsOpen then
 		self:Hide()
@@ -235,17 +237,23 @@ function Window:BeginInput(input, gameProcessed)
 		if self.Cmdr.MashToOpen then
 			if self:IsVisible() then
 				-- Prevent leftover mash presses from instantly closing Cmdr
-				if currentTime - lastPressTime > 1 then
-					self:SetVisible(false)
+				if openedByMash and currentTime - lastPressTime <= 1 then
+					return
 				end
+
+				self:SetVisible(false)
+				lastClosedTime = currentTime
+				openedByMash = false
 
 				return
 			end
 
-			-- Allow reopening without mashing for 10 seconds after opening
-			if currentTime - lastOpenedTime < 10 then
+			-- Allow reopening without mashing for 10 seconds after closing
+			if lastClosedTime and currentTime - lastClosedTime < 10 then
 				self:SetVisible(true)
-				lastOpenedTime = currentTime
+				pressCount = 0
+				lastPressTime = currentTime
+				openedByMash = false
 				return
 			end
 
@@ -254,15 +262,12 @@ function Window:BeginInput(input, gameProcessed)
 
 			if pressCount >= 5 then
 				self:SetVisible(true)
-				lastOpenedTime = currentTime
 				pressCount = 0
+				openedByMash = true
 			end
 		else
 			self:SetVisible(not self:IsVisible())
-
-			if self:IsVisible() then
-				lastOpenedTime = currentTime
-			end
+			openedByMash = false
 		end
 
 		return

--- a/Cmdr/CmdrClient/CreateGui.luau
+++ b/Cmdr/CmdrClient/CreateGui.luau
@@ -1,3 +1,6 @@
+local Players = game:GetService("Players")
+local Player = Players.LocalPlayer
+
 return function()
 	local Cmdr = Instance.new("ScreenGui")
 	Cmdr.DisplayOrder = 1000
@@ -212,6 +215,6 @@ return function()
 	Type.TextXAlignment = Enum.TextXAlignment.Left
 	Type.Parent = Field
 
-	Cmdr.Parent = game:GetService("StarterGui")
+	Cmdr.Parent = Player:WaitForChild("PlayerGui")
 	return Cmdr
 end

--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -1,14 +1,31 @@
 local RunService = game:GetService("RunService")
 local StarterGui = game:GetService("StarterGui")
 local Players = game:GetService("Players")
-local Player = Players.LocalPlayer
+
 local Shared = script:WaitForChild("Shared")
 local Util = require(Shared:WaitForChild("Util"))
+local CreateGui = require(script.CreateGui)
+
+local Player = Players.LocalPlayer
 
 if RunService:IsClient() == false then
 	error(
 		"[Cmdr] Server scripts cannot require the client library. Please require the server library from the server to use Cmdr in your own code."
 	)
+end
+
+local function CreateSignal()
+	local event = Instance.new("BindableEvent")
+
+	return {
+		Fire = function(_, ...)
+			event:Fire(...)
+		end,
+
+		Connect = function(_, callback)
+			return event.Event:Connect(callback)
+		end,
+	}
 end
 
 --[=[
@@ -59,6 +76,20 @@ end
 	The list of key codes that will show or hide Cmdr. Use [`CmdrClient:SetActivationKeys`](#SetActivationKeys) to change.
 ]=]
 
+--[=[
+	@within CmdrClient
+	@prop Gui ScreenGui
+	@readonly
+	Refers to the current Cmdr GUI.
+]=]
+
+--[=[
+	@within CmdrClient
+	@prop Toggled { Connect: (self: ToggleSignal, callback: (visible: boolean) -> ()) -> RBXScriptConnection, Fire: (self: ToggleSignal, visible: boolean) -> () }
+	@readonly
+	A signal that fires when the Cmdr window is toggled.
+]=]
+
 local Cmdr
 do
 	Cmdr = setmetatable({
@@ -67,11 +98,13 @@ do
 		RemoteEvent = script:WaitForChild("CmdrEvent"),
 		ActivationKeys = { [Enum.KeyCode.F2] = true },
 		Enabled = true,
-		MashToEnable = false,
+		MashToOpen = false,
 		ActivationUnlocksMouse = false,
 		HideOnLostFocus = true,
 		PlaceName = "Cmdr",
 		Util = Util,
+		Gui = CreateGui(),
+		Toggled = CreateSignal(),
 		Events = {},
 	}, {
 		-- This sucks, and may be redone or removed
@@ -88,10 +121,6 @@ do
 
 	Cmdr.Registry = require(Shared.Registry)(Cmdr)
 	Cmdr.Dispatcher = require(Shared.Dispatcher)(Cmdr)
-end
-
-if StarterGui:WaitForChild("Cmdr") and wait() and Player:WaitForChild("PlayerGui"):FindFirstChild("Cmdr") == nil then
-	StarterGui.Cmdr:Clone().Parent = Player.PlayerGui
 end
 
 local Interface = require(script.CmdrInterface)(Cmdr)
@@ -173,16 +202,20 @@ end
 	Enables the "Mash to open" feature.
 	This feature, when enabled, requires the activation key to be pressed 5 times within a second to [enable](#SetEnabled) Cmdr.
 	This may be helpful to guard against mispresses from opening the window, for example.
+	Once opened, mashing will be disabled for 10 seconds since it was last opened for convenience.
 
 	@within CmdrClient
 ]=]
-function Cmdr:SetMashToEnable(enabled: boolean)
-	self.MashToEnable = enabled
-
-	if enabled then
-		self:SetEnabled(false)
-	end
+function Cmdr:SetMashToOpen(enabled: boolean)
+	self.MashToOpen = enabled
 end
+
+--[=[
+	@method SetMashToEnable
+	@deprecated v1.13.0 -- This method was renamed to SetMashToOpen in v1.13.0. The old name exists for backwards compatibility and should not be used for new work.
+	@within CmdrClient
+]=]
+Cmdr.SetMashToEnable = Cmdr.SetMashToOpen
 
 --[=[
 	Sets the hide on 'lost focus' feature.
@@ -203,30 +236,28 @@ function Cmdr:HandleEvent(name: string, callback: (...any) -> ())
 	self.Events[name] = callback
 end
 
--- "Only register when we aren't in studio because don't want to overwrite what the server portion did"
--- This is legacy code which predates Accurate Play Solo (which is now the only way to test in studio), this code will never run.
-if RunService:IsServer() == false then
-	local TypesFolder = script:WaitForChild("Types") :: Folder
-	local CommandsFolder = script:WaitForChild("Commands") :: Folder
+-- Register built-in types and commands
+local TypesFolder = script:WaitForChild("Types") :: Folder
+local CommandsFolder = script:WaitForChild("Commands") :: Folder
 
-	Cmdr.Registry:RegisterTypesIn(TypesFolder)
-	Cmdr.Registry:RegisterCommandsIn(CommandsFolder)
+Cmdr.Registry:RegisterTypesIn(TypesFolder)
+Cmdr.Registry:RegisterCommandsIn(CommandsFolder)
 
-	TypesFolder.ChildAdded:Connect(function(child: Instance)
-		if child:IsA("ModuleScript") then
-			require(child)(Cmdr.Registry)
-		else
-			warn(`[Cmdr] Ignored non-module child in Types: {child.Name}`)
-		end
-	end)
-	CommandsFolder.ChildAdded:Connect(function(child: Instance)
-		if child:IsA("ModuleScript") then
-			Cmdr.Registry:RegisterCommand(child)
-		else
-			warn(`[Cmdr] Ignored non-module child in Commands: {child.Name}`)
-		end
-	end)
-end
+TypesFolder.ChildAdded:Connect(function(child: Instance)
+	if child:IsA("ModuleScript") then
+		require(child)(Cmdr.Registry)
+	else
+		warn(`[Cmdr] Ignored non-module child in Types: {child.Name}`)
+	end
+end)
+
+CommandsFolder.ChildAdded:Connect(function(child: Instance)
+	if child:IsA("ModuleScript") then
+		Cmdr.Registry:RegisterCommand(child)
+	else
+		warn(`[Cmdr] Ignored non-module child in Commands: {child.Name}`)
+	end
+end)
 
 -- Hook up event listener
 Cmdr.RemoteEvent.OnClientEvent:Connect(function(name, ...)

--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -200,7 +200,7 @@ end
 
 --[=[
 	Enables the "Mash to open" feature.
-	This feature, when enabled, requires the activation key to be pressed 5 times within a second to [enable](#SetEnabled) Cmdr.
+	This feature, when enabled, requires the [activation key](#SetActivationKeys) to be pressed 5 times within a second to open Cmdr.
 	This may be helpful to guard against mispresses from opening the window, for example.
 	Once opened, mashing will be disabled for 10 seconds since it was last opened for convenience.
 
@@ -213,6 +213,7 @@ end
 --[=[
 	@method SetMashToEnable
 	@deprecated v1.13.0 -- This method was renamed to SetMashToOpen in v1.13.0. The old name exists for backwards compatibility and should not be used for new work.
+	@param enabled boolean
 	@within CmdrClient
 ]=]
 Cmdr.SetMashToEnable = Cmdr.SetMashToOpen

--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -202,7 +202,7 @@ end
 	Enables the "Mash to open" feature.
 	This feature, when enabled, requires the [activation key](#SetActivationKeys) to be pressed 5 times within a second to open Cmdr.
 	This may be helpful to guard against mispresses from opening the window, for example.
-	Once opened, mashing will be disabled for 10 seconds since it was last opened for convenience.
+	Once opened, mashing will be disabled for 10 seconds since it was last closed for convenience.
 
 	@within CmdrClient
 ]=]

--- a/Cmdr/Initialize.luau
+++ b/Cmdr/Initialize.luau
@@ -1,6 +1,4 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local StarterGui = game:GetService("StarterGui")
-local CreateGui = require(script.Parent.CreateGui)
 
 -- Handles initial preparation of the game server-side.
 return function(cmdr)
@@ -33,8 +31,4 @@ return function(cmdr)
 
 	script.Parent.BuiltInTypes:Destroy()
 	script.Parent.BuiltInCommands.Name = "Server commands"
-
-	if StarterGui:FindFirstChild("Cmdr") == nil then
-		CreateGui()
-	end
 end


### PR DESCRIPTION
Improves the `CmdrClient` API and GUI handling by moving more responsibility to the client and exposing additional functionality for developers.

The Cmdr GUI is now created on the client, allowing `CdmrClient.Gui` to provide direct access to the current GUI instance. This also fixes issues with duplicate GUI instances being created and resolves several textbox capture/focus issues.

The mash activation system has also been reworked by replacing `SetMashToEnable` with `SetMashToOpen`. This better represents its purpose as an activation method rather than a way of controlling whether Cmdr is enabled, preventing it from overriding developer calls to `CmdrClient:SetEnabled`. The old method still exists for backwards compatability but was marked as deprecated.

Additionally, this adds the `CmdrClient.Toggeld` signal for listening to visibility changes and introduces a new `exit` command. The `clean` command has been updated to make use of the new `CmdrClient.Gui` property.

Closes #298, #310, #354

## Test Code
```lua
local ReplicatedStorage = game:GetService("ReplicatedStorage")
local Players = game:GetService("Players")

local Cmdr = require(ReplicatedStorage:WaitForChild("CmdrClient"))

local Player = Players.LocalPlayer
local PlayerGui = Player:WaitForChild("PlayerGui")

local CmdrGui = Cmdr.Gui
local ButtonGui = Instance.new("ScreenGui")
local OpenButton = Instance.new("TextButton")

Cmdr:SetActivationKeys({ Enum.KeyCode.F2 })
Cmdr:SetMashToOpen(true)
Cmdr.Toggled:Connect(function(visible: boolean)
	print(visible)
end)

ButtonGui.Parent = PlayerGui
OpenButton.Parent = ButtonGui
OpenButton.Size = UDim2.fromOffset(200, 50)
OpenButton.BackgroundColor3 = Color3.new(1, 1, 1)
OpenButton.MouseButton1Click:Connect(function()
	Cmdr:Toggle()
end)

CmdrGui.Frame.Entry.TextLabel.TextColor3 = Color3.new(0, 1, 0)
```

## Declarations
- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

