### PR TITLE
refactor: remove support for LegacyChatService from bind command

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -65,13 +65,9 @@ return {
 				)
 			end
 
-			if TextChatService.ChatVersion == Enum.ChatVersion.LegacyChatService then
-				binds[bind] = bind.Chatted:Connect(RunCommand)
-			else
-				binds[bind] = TextChatService.SendingMessage:Connect(function(message)
-					RunCommand(message.Text)
-				end)
-			end
+			binds[bind] = TextChatService.SendingMessage:Connect(function(message)
+				RunCommand(message.Text)
+			end)
 		end
 
 		return "Bound command to input."

--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -53,20 +53,17 @@ return {
 		elseif bindType == "bindableResource" then
 			return "Unimplemented..."
 		elseif bindType == "player" then
-			local function RunCommand(message)
-				local args = { message }
+			binds[bind] = TextChatService.SendingMessage:Connect(function(message)
+				local args = { message.Text }
 				local chatCommand = context.Cmdr.Util.RunEmbeddedCommands(
 					context.Dispatcher,
 					context.Cmdr.Util.SubstituteArgs(command, args)
 				)
+
 				context:Reply(
 					("%s $ %s : %s"):format(bind.Name, chatCommand, context.Dispatcher:EvaluateAndRun(chatCommand)),
 					Color3.fromRGB(244, 92, 66)
 				)
-			end
-
-			binds[bind] = TextChatService.SendingMessage:Connect(function(message)
-				RunCommand(message.Text)
 			end)
 		end
 


### PR DESCRIPTION
Removes support for Roblox's deprecated LegacyChatService from the `bind` command.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

