### PR TITLE
fix: check for developer created Guis in StarterGui

### DIFF
--- a/Cmdr/CmdrClient/CreateGui.luau
+++ b/Cmdr/CmdrClient/CreateGui.luau
@@ -1,7 +1,14 @@
 local Players = game:GetService("Players")
+local StarterGui = game:GetService("StarterGui")
+
 local Player = Players.LocalPlayer
+local PlayerGui = Player:WaitForChild("PlayerGui")
 
 return function()
+	if StarterGui:FindFirstChild("Cmdr") then
+		return PlayerGui:WaitForChild("Cmdr")
+	end
+
 	local Cmdr = Instance.new("ScreenGui")
 	Cmdr.DisplayOrder = 1000
 	Cmdr.Name = "Cmdr"
@@ -215,6 +222,6 @@ return function()
 	Type.TextXAlignment = Enum.TextXAlignment.Left
 	Type.Parent = Field
 
-	Cmdr.Parent = Player:WaitForChild("PlayerGui")
+	Cmdr.Parent = PlayerGui
 	return Cmdr
 end


### PR DESCRIPTION
Checks the StarterGui for a developer created Cmdr Gui before creating a new one

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

