### PR TITLE
feat: implement Deprecation Warnings

### DIFF
--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -211,12 +211,18 @@ function Cmdr:SetMashToOpen(enabled: boolean)
 end
 
 --[=[
-	@method SetMashToEnable
 	@deprecated v1.13.0 -- This method was renamed to SetMashToOpen in v1.13.0. The old name exists for backwards compatibility and should not be used for new work.
-	@param enabled boolean
 	@within CmdrClient
 ]=]
-Cmdr.SetMashToEnable = Cmdr.SetMashToOpen
+function Cmdr:SetMashToEnable(enabled: boolean)
+	Util:_emitDeprecationWarning("SetMashToEnable")
+	Cmdr:SetMashToOpen(enabled)
+end
+
+Util:_registerDeprecationWarning(
+	"SetMashToEnable",
+	"This method was renamed to SetMashToOpen in v1.13.0. The old name exists for backwards compatibility and should not be used for new work."
+)
 
 --[=[
 	Sets the hide on 'lost focus' feature.

--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -216,7 +216,7 @@ end
 ]=]
 function Cmdr:SetMashToEnable(enabled: boolean)
 	Util:_emitDeprecationWarning("SetMashToEnable")
-	Cmdr:SetMashToOpen(enabled)
+	self:SetMashToOpen(enabled)
 end
 
 Util:_registerDeprecationWarning(

--- a/Cmdr/Shared/Registry.luau
+++ b/Cmdr/Shared/Registry.luau
@@ -586,7 +586,7 @@ end
 ]=]
 function Registry:AddHook(...)
 	Util:_emitDeprecationWarning("AddHook")
-	Registry:RegisterHook(...)
+	self:RegisterHook(...)
 end
 
 Util:_registerDeprecationWarning(

--- a/Cmdr/Shared/Registry.luau
+++ b/Cmdr/Shared/Registry.luau
@@ -382,9 +382,7 @@ function Registry:RegisterCommand(
 	local commandObject = require(commandScript)
 	assert(
 		typeof(commandObject) == "table",
-		`[Cmdr] Invalid return value from command script "{commandScript.Name}" (CommandDefinition expected, got {typeof(
-			commandObject
-		)})`
+		`[Cmdr] Invalid return value from command script "{commandScript.Name}" (CommandDefinition expected, got {typeof(commandObject)})`
 	)
 
 	if commandServerScript then

--- a/Cmdr/Shared/Registry.luau
+++ b/Cmdr/Shared/Registry.luau
@@ -382,7 +382,9 @@ function Registry:RegisterCommand(
 	local commandObject = require(commandScript)
 	assert(
 		typeof(commandObject) == "table",
-		`[Cmdr] Invalid return value from command script "{commandScript.Name}" (CommandDefinition expected, got {typeof(commandObject)})`
+		`[Cmdr] Invalid return value from command script "{commandScript.Name}" (CommandDefinition expected, got {typeof(
+			commandObject
+		)})`
 	)
 
 	if commandServerScript then
@@ -513,7 +515,15 @@ end
 	@deprecated v1.8.0 -- This method was renamed to GetCommandNames in v1.8.0. The old name exists for backwards compatibility and should not be used for new work.
 	@within Registry
 ]=]
-Registry.GetCommandsAsStrings = Registry.GetCommandNames
+function Registry:GetCommandsAsStrings(): { string }
+	Util:_emitDeprecationWarning("GetCommandsAsStrings")
+	return self:GetCommandNames()
+end
+
+Util:_registerDeprecationWarning(
+	"GetCommandsAsStrings",
+	"This method was renamed to GetCommandNames in v1.8.0. The old name exists for backwards compatibility and should not be used for new work."
+)
 
 --[=[
 	Returns an array of containing the names of all registered types, not including aliases.
@@ -576,7 +586,15 @@ end
 	@param priority number -- If unspecified, the priority will default to `0`.
 	@within Registry
 ]=]
-Registry.AddHook = Registry.RegisterHook
+function Registry:AddHook(...)
+	Util:_emitDeprecationWarning("AddHook")
+	Registry:RegisterHook(...)
+end
+
+Util:_registerDeprecationWarning(
+	"AddHook",
+	"This method was renamed to RegisterHook in v1.1.2. The old name exists for backwards compatibility and should not be used for new work."
+)
 
 --[=[
 	Returns a table saved with the given name. Always returns the same table on subsequent calls. Useful for commands that require persistent state, like bind or ban.

--- a/Cmdr/Shared/Util.luau
+++ b/Cmdr/Shared/Util.luau
@@ -652,9 +652,11 @@ end
 	@private
 ]=]
 function Util:_registerDeprecationWarning(name: string, description: string)
-	assert(type(name) == "string", "[Cmdr] Deprecation warning name must be a string.")
-	assert(type(description) == "string", "[Cmdr] Deprecation warning description must be a string.")
-	assert(#name > 0, "[Cmdr] Deprecation warning name must not be empty.")
+	assert(type(name) == "string" and #name > 0, "[Cmdr] Deprecation warning name must be a string.")
+	assert(
+		type(description) == "string" and #description > 0,
+		"[Cmdr] Deprecation warning description must be a string."
+	)
 	assert(not self._deprecationWarnings[name], `[Cmdr] Deprecation warning {name} is already registered.`)
 
 	self._deprecationWarnings[name] = {
@@ -691,7 +693,7 @@ function Util:SuppressDeprecationWarning(warnings: string | { string })
 		type(warnings) == "string" or type(warnings) == "table",
 		"[Cmdr] Deprecation warning name(s) must be a string or an array of strings."
 	)
-	assert(type(warnings) == "string" or #warnings > 0, "[Cmdr] Deprecation warning name(s) must not be empty.")
+	assert(#warnings > 0, "[Cmdr] Deprecation warning name(s) must not be empty.")
 
 	if type(warnings) == "string" then
 		warnings = { warnings }

--- a/Cmdr/Shared/Util.luau
+++ b/Cmdr/Shared/Util.luau
@@ -10,6 +10,7 @@ local TextService = game:GetService("TextService")
 	:::
 ]=]
 local Util = {}
+Util._deprecationWarnings = {} :: { [string]: { Description: string, Suppressed: boolean, Emitted: boolean } }
 
 --[=[
 	Takes an array and flips its values into dictionary keys with value of true.
@@ -639,6 +640,67 @@ function Util.Mutex()
 				locked = false
 			end
 		end
+	end
+end
+
+--[=[
+	Registers a deprecation warning for a method.
+	@param name string -- The name of the method being deprecated.
+	@param description string -- A description of the deprecation warning.
+	@error InvalidArgument -- The provided name or description is not a string.
+	@error DuplicateDeprecationWarning -- The provided deprecation warning name has already been registered
+	@private
+]=]
+function Util:_registerDeprecationWarning(name: string, description: string)
+	assert(type(name) == "string", "[Cmdr] Deprecation warning name must be a string.")
+	assert(type(description) == "string", "[Cmdr] Deprecation warning description must be a string.")
+	assert(#name > 0, "[Cmdr] Deprecation warning name must not be empty.")
+	assert(not self._deprecationWarnings[name], `[Cmdr] Deprecation warning {name} is already registered.`)
+
+	self._deprecationWarnings[name] = {
+		Description = description,
+		Suppressed = false,
+		Emitted = false,
+	}
+end
+
+--[=[
+	Emits a deprecation warning for a method if it has been called. This should be called at the start of a deprecated method.
+	@param name string -- The name of the method being deprecated.
+	@error UnknownDeprecationWarning -- The provided deprecation warning name has not been registered.
+	@private
+]=]
+function Util:_emitDeprecationWarning(name: string)
+	local warningInfo = self._deprecationWarnings[name]
+	assert(warningInfo, `[Cmdr] Unknown deprecation warning {name}.`)
+
+	if not warningInfo.Suppressed and not warningInfo.Emitted then
+		warn(debug.traceback(`[Cmdr] [DeprecationWarning::{name}] {warningInfo.Description}`, 2))
+		warningInfo.Emitted = true
+	end
+end
+
+--[=[
+	Suppresses a deprecation warning for a method.
+	@param warnings string | { string } -- The name(s) of the method(s) to suppress warnings for.
+	@error InvalidArgument -- The provided warning name(s) must be a string or an array of strings.
+	@error UnknownDeprecationWarning -- One or more provided warning names have not been registered.
+]=]
+function Util:SuppressDeprecationWarning(warnings: string | { string })
+	assert(
+		type(warnings) == "string" or type(warnings) == "table",
+		"[Cmdr] Deprecation warning name(s) must be a string or an array of strings."
+	)
+	assert(type(warnings) == "string" or #warnings > 0, "[Cmdr] Deprecation warning name(s) must not be empty.")
+
+	if type(warnings) == "string" then
+		warnings = { warnings }
+	end
+
+	for _, name in pairs(warnings) do
+		assert(type(name) == "string", "[Cmdr] Deprecation warning names must be strings.")
+		assert(self._deprecationWarnings[name], `[Cmdr] Unknown deprecation warning {name}.`)
+		self._deprecationWarnings[name].Suppressed = true
 	end
 end
 


### PR DESCRIPTION
This implements a deprecation warning system, allowing deprecated APIs to provide clear feedback to developers while maintaining backwards compatibility. Deprecated methods can now register a warning through `Util` and emit that warning when called.

Deprecation warnings are registered with a descriptive PascalCase name and a longer message explaining the replacement. When emitted, the warning includes the name, description, and a stack trace pointing back to the deprecated method that triggered it.
Closes #305 

Example output:
```
[Cmdr] [DeprecationWarning::AddHook] This method was renamed to RegisterHook in v1.1.2. The old name exists for backwards compatibility and should not be used for new work.
ReplicatedStorage.CmdrClient.Shared.Registry:590 function AddHook
Players.KSSAdministration.PlayerScripts.Client:8
```

## Deprecation API
Deprecated methods can now be marked with `Util:_registerDeprecationWarning(<name>, <description>)` and emit a warning with `Util:_emitDeprecationWarning(<name>)`, like so:
```lua
function Registry:AddHook(...)
	Util:_emitDeprecationWarning("AddHook")
	Registry:RegisterHook(...)
end

Util:_registerDeprecationWarning(
	"AddHook",
	"This method was renamed to RegisterHook in v1.1.2. The old name exists for backwards compatibility and should not be used for new work."
)
```

The deprecated API continues to work normally, but users are informed that it should no longer be used for new code.

## Warning suppression
A new `Util:SuppressDeprecationWarning` method allows developers to silence specific deprecation warnings when needed:
```lua
Util:SuppressDeprecationWarning("SetMashToEnable")
Util:SuppressDeprecationWarning({"SetMashToEnable", "GetCommandsAsStrings"})
```

## Test Code
```lua
local ReplicatedStorage = game:GetService("ReplicatedStorage")
local CmdrClient = require(ReplicatedStorage:WaitForChild("CmdrClient"))

CmdrClient.Util:SuppressDeprecationWarning({"SetMashToEnable", "GetCommandsAsStrings"})
CmdrClient:SetMashToEnable(true) -- No warning, it was supressed!
print(CmdrClient.Registry:GetCommandsAsStrings()) -- No warning, it was also supressed!

CmdrClient.Registry:AddHook("BeforeRun", function(context) -- Deprecation Warning, it's not supressed!
	print("This hook should throw a warning!")
end)
```

## Declarations
- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.