### PR TITLE
fix: bind Command for proper TextChatService support

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -3,7 +3,7 @@ local TextChatService = game:GetService("TextChatService")
 local UserInputService = game:GetService("UserInputService")
 
 local hasHelperRan = false
-local function RunBindHelper(Cmdr)
+local function runBindHelper(Cmdr)
 	Players.PlayerRemoving:Connect(function(Player)
 		local binds = Cmdr.Registry:GetStore("CMDR_Binds")
 		if binds[Player] then
@@ -53,7 +53,7 @@ return {
 
 	ClientRun = function(context, bind, command, arguments)
 		if not hasHelperRan then
-			RunBindHelper(context.Cmdr)
+			runBindHelper(context.Cmdr)
 		end
 
 		local binds = context:GetStore("CMDR_Binds")

--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -58,7 +58,11 @@ return {
 
 		local binds = context:GetStore("CMDR_Binds")
 		if binds[bind] then
-			binds[bind]:Disconnect()
+			if typeof(binds[bind]) == "RBXScriptConnection" then
+				binds[bind]:Disconnect()
+			end
+
+			binds[bind] = nil
 		end
 
 		command = command .. " " .. arguments

--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -1,5 +1,31 @@
-local UserInputService = game:GetService("UserInputService")
+local Players = game:GetService("Players")
 local TextChatService = game:GetService("TextChatService")
+local UserInputService = game:GetService("UserInputService")
+
+local hasHelperRun = false
+local function RunBindHelper(Cmdr)
+	Players.PlayerRemoving:Connect(function(Player)
+		local binds = Cmdr.Registry:GetStore("CMDR_Binds")
+		if binds[Player] then
+			binds[Player] = nil
+		end
+	end)
+
+	TextChatService.MessageReceived:Connect(function(message: TextChatMessage)
+		local senderId = message.TextSource and message.TextSource.UserId
+		local player = senderId and Players:GetPlayerByUserId(senderId)
+		if not player then
+			return
+		end
+
+		local binds = Cmdr.Registry:GetStore("CMDR_Binds")
+		if binds[player] then
+			binds[player](message)
+		end
+	end)
+
+	hasHelperRun = true
+end
 
 return {
 	Name = "bind",
@@ -26,16 +52,18 @@ return {
 	},
 
 	ClientRun = function(context, bind, command, arguments)
+		if not hasHelperRun then
+			RunBindHelper(context.Cmdr)
+		end
+
 		local binds = context:GetStore("CMDR_Binds")
-
-		command = command .. " " .. arguments
-
 		if binds[bind] then
 			binds[bind]:Disconnect()
 		end
 
-		local bindType = context:GetArgument(1).Type.Name
+		command = command .. " " .. arguments
 
+		local bindType = context:GetArgument(1).Type.Name
 		if bindType == "userInput" then
 			binds[bind] = UserInputService.InputBegan:Connect(function(input, gameProcessed)
 				if gameProcessed then
@@ -53,24 +81,17 @@ return {
 		elseif bindType == "bindableResource" then
 			return "Unimplemented..."
 		elseif bindType == "player" then
-			local function RunCommand(message)
-				local args = { message }
+			binds[bind] = function(message: TextChatMessage)
+				local args = { message.Text }
 				local chatCommand = context.Cmdr.Util.RunEmbeddedCommands(
 					context.Dispatcher,
 					context.Cmdr.Util.SubstituteArgs(command, args)
 				)
+
 				context:Reply(
 					("%s $ %s : %s"):format(bind.Name, chatCommand, context.Dispatcher:EvaluateAndRun(chatCommand)),
 					Color3.fromRGB(244, 92, 66)
 				)
-			end
-
-			if TextChatService.ChatVersion == Enum.ChatVersion.LegacyChatService then
-				binds[bind] = bind.Chatted:Connect(RunCommand)
-			else
-				binds[bind] = TextChatService.SendingMessage:Connect(function(message)
-					RunCommand(message.Text)
-				end)
 			end
 		end
 

--- a/Cmdr/BuiltInCommands/Utility/bind.luau
+++ b/Cmdr/BuiltInCommands/Utility/bind.luau
@@ -2,7 +2,7 @@ local Players = game:GetService("Players")
 local TextChatService = game:GetService("TextChatService")
 local UserInputService = game:GetService("UserInputService")
 
-local hasHelperRun = false
+local hasHelperRan = false
 local function RunBindHelper(Cmdr)
 	Players.PlayerRemoving:Connect(function(Player)
 		local binds = Cmdr.Registry:GetStore("CMDR_Binds")
@@ -24,7 +24,7 @@ local function RunBindHelper(Cmdr)
 		end
 	end)
 
-	hasHelperRun = true
+	hasHelperRan = true
 end
 
 return {
@@ -52,7 +52,7 @@ return {
 	},
 
 	ClientRun = function(context, bind, command, arguments)
-		if not hasHelperRun then
+		if not hasHelperRan then
 			RunBindHelper(context.Cmdr)
 		end
 

--- a/Cmdr/BuiltInCommands/Utility/unbind.luau
+++ b/Cmdr/BuiltInCommands/Utility/unbind.luau
@@ -11,12 +11,15 @@ return {
 		},
 	},
 
-	ClientRun = function(context, inputEnum)
+	ClientRun = function(context, bind)
 		local binds = context:GetStore("CMDR_Binds")
 
-		if binds[inputEnum] then
-			binds[inputEnum]:Disconnect()
-			binds[inputEnum] = nil
+		if binds[bind] then
+			if typeof(binds[bind]) == "RBXScriptConnection" then
+				binds[bind]:Disconnect()
+			end
+
+			binds[bind] = nil
 			return "Unbound command from input."
 		else
 			return "That input wasn't bound."


### PR DESCRIPTION
Removes LegacyChatService support from the bind command in favor of TextChatService. Also adds proper cleanup for player-bound binds when players leave and consolidates MessageReceived handling into a shared connection with the use of a helper function to prevent unnecessary event connections.

## Declarations:
- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.

