### PR TITLE
Re-add calls and hashtag to `var` commands

### DIFF
--- a/Cmdr/BuiltInCommands/Utility/varServer.luau
+++ b/Cmdr/BuiltInCommands/Utility/varServer.luau
@@ -1,26 +1,4 @@
-const DataStoreService = game:GetService("DataStoreService")
-
-const queue = {}
-local DataStoresActive, DataStore
-task.spawn(function()
-	DataStoresActive, DataStore = pcall(function()
-		const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
-		targetStore:GetAsync("test_key")
-		return targetStore
-	end)
-
-	while #queue > 0 do
-		const nextThread = table.remove(queue, 1)
-		coroutine.resume(nextThread)
-	end
-end)
-
 return function(context: any, key: string): string
-	if DataStoresActive == nil then
-		table.insert(queue, coroutine.running())
-		coroutine.yield()
-	end
-
 	local gameWide = false
 	local saved = true
 
@@ -37,8 +15,9 @@ return function(context: any, key: string): string
 	const namespace = `var_{if gameWide then "global" else tostring(context.Executor.UserId)}`
 
 	if saved then
+		const dataStore = context.Cmdr.Util.GetDataStore()
 		const keyPath = `{namespace}_{key}`
-		const value = DataStore:GetAsync(keyPath) or ""
+		const value = dataStore:GetAsync(keyPath) or ""
 
 		if type(value) == "table" then
 			return table.concat(value, ",") or ""

--- a/Cmdr/BuiltInCommands/Utility/varServer.luau
+++ b/Cmdr/BuiltInCommands/Utility/varServer.luau
@@ -1,7 +1,26 @@
 const DataStoreService = game:GetService("DataStoreService")
-const DataStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
+
+const queue = {}
+local DataStoresActive, DataStore
+task.spawn(function()
+	DataStoresActive, DataStore = pcall(function()
+		const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
+		targetStore:GetAsync("test_key")
+		return targetStore
+	end)
+
+	while #queue > 0 do
+		const nextThread = table.remove(queue, 1)
+		coroutine.resume(nextThread)
+	end
+end)
 
 return function(context: any, key: string): string
+	if DataStoresActive == nil then
+		table.insert(queue, coroutine.running())
+		coroutine.yield()
+	end
+
 	local gameWide = false
 	local saved = true
 

--- a/Cmdr/BuiltInCommands/Utility/varSetServer.luau
+++ b/Cmdr/BuiltInCommands/Utility/varSetServer.luau
@@ -1,7 +1,26 @@
 const DataStoreService = game:GetService("DataStoreService")
-const DataStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
+
+const queue = {}
+local DataStoresActive, DataStore
+task.spawn(function()
+	DataStoresActive, DataStore = pcall(function()
+		const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
+		targetStore:GetAsync("test_key")
+		return targetStore
+	end)
+
+	while #queue > 0 do
+		const nextThread = table.remove(queue, 1)
+		coroutine.resume(nextThread)
+	end
+end)
 
 return function(context: any, key: string, value: string): string
+	if DataStoresActive == nil then
+		table.insert(queue, coroutine.running())
+		coroutine.yield()
+	end
+
 	local gameWide = false
 	local saved = true
 

--- a/Cmdr/BuiltInCommands/Utility/varSetServer.luau
+++ b/Cmdr/BuiltInCommands/Utility/varSetServer.luau
@@ -1,26 +1,4 @@
-const DataStoreService = game:GetService("DataStoreService")
-
-const queue = {}
-local DataStoresActive, DataStore
-task.spawn(function()
-	DataStoresActive, DataStore = pcall(function()
-		const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
-		targetStore:GetAsync("test_key")
-		return targetStore
-	end)
-
-	while #queue > 0 do
-		const nextThread = table.remove(queue, 1)
-		coroutine.resume(nextThread)
-	end
-end)
-
 return function(context: any, key: string, value: string): string
-	if DataStoresActive == nil then
-		table.insert(queue, coroutine.running())
-		coroutine.yield()
-	end
-
 	local gameWide = false
 	local saved = true
 
@@ -37,8 +15,9 @@ return function(context: any, key: string, value: string): string
 	const namespace = `var_{if gameWide then "global" else tostring(context.Executor.UserId)}`
 
 	if saved then
+		const dataStore = context.Cmdr.Util.GetDataStore()
 		const keyPath = `{namespace}_{key}`
-		DataStore:SetAsync(keyPath, value)
+		dataStore:SetAsync(keyPath, value)
 
 		return value
 	else

--- a/Cmdr/CmdrClient/Shared/BuiltInGuards/IsDataStoreAvailable.luau
+++ b/Cmdr/CmdrClient/Shared/BuiltInGuards/IsDataStoreAvailable.luau
@@ -47,7 +47,7 @@ return function(index: number)
 
 		if RunService:IsClient() then
 			if game.PlaceId == 0 then
-				return "You must publish this place to the web to use saved keys."
+				return "# You must publish this place to the web to use saved keys."
 			end
 		else
 			if dataStoresActive == nil then
@@ -56,7 +56,7 @@ return function(index: number)
 			end
 
 			if not dataStoresActive then
-				return "You must publish this place to the web to use saved keys."
+				return "# You must publish this place to the web to use saved keys."
 			end
 		end
 

--- a/Cmdr/CmdrClient/Shared/BuiltInGuards/IsDataStoreAvailable.luau
+++ b/Cmdr/CmdrClient/Shared/BuiltInGuards/IsDataStoreAvailable.luau
@@ -1,27 +1,4 @@
-const DataStoreService = game:GetService("DataStoreService")
 const RunService = game:GetService("RunService")
-
-local dataStoresActive: boolean? = nil
-const queue: { thread } = {}
-
-if RunService:IsServer() then
-	task.spawn(function()
-		local success
-		success = pcall(function()
-			const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
-			targetStore:GetAsync("test_key")
-		end)
-
-		dataStoresActive = success
-
-		while #queue > 0 do
-			const nextThread = table.remove(queue, 1)
-			if nextThread then
-				coroutine.resume(nextThread)
-			end
-		end
-	end)
-end
 
 return function(index: number)
 	return function(context: any): string?
@@ -33,6 +10,7 @@ return function(index: number)
 		end
 
 		local saved = true
+
 		if key:sub(1, 1) == "$" then
 			key = key:sub(2)
 		end
@@ -49,15 +27,8 @@ return function(index: number)
 			if game.PlaceId == 0 then
 				return "# You must publish this place to the web to use saved keys."
 			end
-		else
-			if dataStoresActive == nil then
-				table.insert(queue, coroutine.running())
-				coroutine.yield()
-			end
-
-			if not dataStoresActive then
-				return "# You must publish this place to the web to use saved keys."
-			end
+		elseif not context.Cmdr.Util.GetDataStore() then
+			return "# You must publish this place to the web to use saved keys."
 		end
 
 		return nil

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -1,6 +1,12 @@
 -- Here be dragons
 
+const DataStoreService = game:GetService("DataStoreService")
+const RunService = game:GetService("RunService")
 const TextService = game:GetService("TextService")
+
+local dataStoreActive: boolean? = nil
+local dataStore: GlobalDataStore? = nil
+const dataStoreQueue: { thread } = {}
 
 const CMDR_ESCAPE = "___!CMDR_ESCAPE!___"
 const CMDR_QUOTE = "___!CMDR_QUOTE!___"
@@ -14,6 +20,30 @@ const END_QUOTE_PATTERN = [=[(['"])$]=]
 const ESCAPED_QUOTE_PATTERN = [=[(\*)['"]$]=]
 
 const CACHED_LABELS = setmetatable({}, { __mode = "k" })
+
+if RunService:IsServer() then
+	task.spawn(function()
+		const success, result = pcall(function()
+			const targetStore = DataStoreService:GetDataStore("_package/eryn.io/Cmdr")
+			targetStore:GetAsync("test_key")
+			return targetStore
+		end)
+
+		dataStoreActive = success
+
+		if success then
+			dataStore = result
+		end
+
+		while #dataStoreQueue > 0 do
+			const nextThread = table.remove(dataStoreQueue, 1)
+
+			if nextThread then
+				coroutine.resume(nextThread)
+			end
+		end
+	end)
+end
 
 -- Converts instances into display names and keeps the original values.
 const function transformInstanceSet(instances: { any }): ({ string }, { any })
@@ -75,6 +105,19 @@ end
 const Util = {
 	_deprecationWarnings = {} :: { [string]: { Description: string, Suppressed: boolean, Emitted: boolean } },
 }
+
+function Util.GetDataStore(): GlobalDataStore?
+	if RunService:IsClient() then
+		return
+	end
+
+	if dataStoreActive == nil then
+		table.insert(dataStoreQueue, coroutine.running())
+		coroutine.yield()
+	end
+
+	return dataStore
+end
 
 --[=[
 	@within Util


### PR DESCRIPTION
Closes #419. While GetDataStore emits a Studio error for published games with API access off, it emits a fatal error when used in a local place file. Also, the hashtag is required in error messages as `run-lines` skips any lines starting with them.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
