### PR TITLE
Clear entry text after capturing focus

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -219,8 +219,8 @@ return function(CmdrClient, AutoComplete)
 			self:_setChatEnabled(false)
 			self:_setMouseUnlocked(true)
 
-			self._entry.TextBox:CaptureFocus()
 			self:_setEntryText("")
+			self._entry.TextBox:CaptureFocus()
 		else
 			self:_setChatEnabled(true)
 			self:_setMouseUnlocked(false)
@@ -459,7 +459,7 @@ return function(CmdrClient, AutoComplete)
 
 		-- Check for activation shortcut keys
 		if table.find(CmdrClient._activationKeys, input.KeyCode) then
-			self:_handleActivationKey()
+			task.defer(self._handleActivationKey, self)
 			return
 		end
 

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -219,8 +219,8 @@ return function(CmdrClient, AutoComplete)
 			self:_setChatEnabled(false)
 			self:_setMouseUnlocked(true)
 
-			self:_setEntryText("")
 			self._entry.TextBox:CaptureFocus()
+			self:_setEntryText("")
 		else
 			self:_setChatEnabled(true)
 			self:_setMouseUnlocked(false)


### PR DESCRIPTION
Closes #423. Activation key is captured in the console in the previous order. Clearing entry text after capturing focus will ensure that it removed.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
