### PR TITLE
fix(util): handle empty excess arguments in MashExcessArguments

### DIFF
--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -392,7 +392,7 @@ function Util.MashExcessArguments(arguments: { string }, max: number): { string 
 
 	for argumentIndex = 1, #arguments do
 		if argumentIndex > max then
-			results[max] ..= ` {arguments[argumentIndex]}`
+			results[max] = (results[max] or "") .. ` {arguments[argumentIndex]}`
 		else
 			results[argumentIndex] = arguments[argumentIndex]
 		end


### PR DESCRIPTION
Closes #426. Ensures `MashExcessArguments` safely handles nil values when concatenating excess arguments.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
