### PR TITLE
Improve `ProxyCalls` deprecation warning

### DIFF
--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -869,4 +869,11 @@ function Util:SuppressDeprecationWarning(names: string | { string })
 	end
 end
 
+Util:_registerDeprecationWarning(
+	"ProxyCalls",
+	`Method calls should be performed against their respective modules rather than the {if RunService:IsServer()
+		then "Cmdr"
+		else "CmdrClient"} object. Proxy calls are deprecated, they exist for backwards compatibility and should not be used for new work.`
+)
+
 return Util

--- a/Cmdr/CmdrClient/init.luau
+++ b/Cmdr/CmdrClient/init.luau
@@ -362,15 +362,7 @@ return setmetatable(CmdrClient, {
 		assert(value, `[Cmdr] Dispatcher has no method or property "{key}".`)
 
 		if type(value) == "function" then
-			if not script:GetAttribute("HasShownProxyCallWarning") then
-				warn(
-					debug.traceback(
-						`[Cmdr] [APIUsage::ProxyCalls] Method calls should be performed by their respective modules rather than the Cmdr object.`,
-						2
-					)
-				)
-				script:SetAttribute("HasShownProxyCallWarning", true)
-			end
+			Util:_emitDeprecationWarning("ProxyCalls")
 
 			return function(_, ...)
 				return value(dispatcher, ...)

--- a/Cmdr/init.luau
+++ b/Cmdr/init.luau
@@ -88,7 +88,7 @@ end
 	@private
 
 	@prop _replicatedRoot ModuleScript
-	
+
 	Refers to the CmdrClient modulescript containing all shared functionality.
 ]=]
 
@@ -163,15 +163,7 @@ return setmetatable(Cmdr, {
 		assert(value, `[Cmdr] Registry has no method or property "{key}".`)
 
 		if type(value) == "function" then
-			if not self._replicatedRoot:GetAttribute("HasShownProxyCallWarning") then
-				warn(
-					debug.traceback(
-						`[Cmdr] [APIUsage::ProxyCalls] Method calls should be performed by their respective modules rather than the Cmdr object.`,
-						2
-					)
-				)
-				self._replicatedRoot:SetAttribute("HasShownProxyCallWarning", true)
-			end
+			Util:_emitDeprecationWarning("ProxyCalls")
 
 			return function(_, ...)
 				return value(registry, ...)


### PR DESCRIPTION
Currently `APIUsage::ProxyCalls` exists as a special case warning, instead of being a deprecation warning. This replaces that special case with a standard deprecation warning, and makes the wording clearer.

Well, an attempt has been made to make the warning clearer. I'm not sure what exactly would be the *perfect* wording here, but this at least makes it clear that it's a deprecated thing. I think further improvement is necessary (and this should be made to the patch, and obviously in that case edit this bit of the commit message accordingly).

Closes #415

@ShadowDaughter Your rv would be appreciated here. 

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
