### PR TITLE
Fix `:exit` re-enabling chat UI the game had disabled

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -172,15 +172,20 @@ return function(CmdrClient, AutoComplete)
 			TextChatService.ChannelTabsConfiguration.Enabled = false
 		else
 			-- Restore previous state
-			TextChatService.ChatWindowConfiguration.Enabled = if self._previousChatWindowEnabled ~= nil
-				then self._previousChatWindowEnabled
-				else true
-			TextChatService.ChatInputBarConfiguration.Enabled = if self._previousChatInputBarEnabled ~= nil
-				then self._previousChatInputBarEnabled
-				else true
-			TextChatService.ChannelTabsConfiguration.Enabled = if self._previousChannelTabsEnabled ~= nil
-				then self._previousChannelTabsEnabled
-				else true
+			if self._previousChatWindowEnabled ~= nil then
+				TextChatService.ChatWindowConfiguration.Enabled = self._previousChatWindowEnabled
+				self._previousChatWindowEnabled = nil
+			end
+
+			if self._previousChatInputBarEnabled ~= nil then
+				TextChatService.ChatInputBarConfiguration.Enabled = self._previousChatInputBarEnabled
+				self._previousChatInputBarEnabled = nil
+			end
+
+			if self._previousChannelTabsEnabled ~= nil then
+				TextChatService.ChannelTabsConfiguration.Enabled = self._previousChannelTabsEnabled
+				self._previousChannelTabsEnabled = nil
+			end
 		end
 	end
 
@@ -213,6 +218,10 @@ return function(CmdrClient, AutoComplete)
 		Sets whether the command bar is visible.
 	]=]
 	function Window:SetVisible(visible: boolean)
+		if entryFrame.Visible == visible then
+			return
+		end
+
 		entryFrame.Visible = visible
 
 		if visible then


### PR DESCRIPTION
Running `:exit` (or any `Cmdr:Hide()`) before the window has ever been opened force-enabled `ChatWindowConfiguration`, `ChatInputBarConfiguration`, and `ChannelTabsConfiguration`, unhiding chat UI in games that deliberately disable it. 

`Window:_setChatEnabled(false)` is what saves the previous state, so if the window was never shown, the saved values are `nil` and the restore branch fell back to `true`.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
