### PR TITLE
Support non-blocking execution of promise-returning commands

### DIFF
--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -385,7 +385,7 @@ return function(CmdrClient, AutoComplete)
 				self:_setEntryText("")
 				self._processEntry(text)
 			else
-				self:AddLine(self._errorText, Color3.fromRGB(255, 153, 153))
+				self:AddLine(self._errorText, CmdrClient.Util.ErrorColor)
 			end
 
 			self._hasLostFocus = false

--- a/Cmdr/CmdrClient/CmdrInterface/Window.luau
+++ b/Cmdr/CmdrClient/CmdrInterface/Window.luau
@@ -346,7 +346,12 @@ return function(CmdrClient, AutoComplete)
 		end
 
 		Window:AddLine(`{Window:GetLabelText()} {text}`, PROCESSING_TEXT_COLOR)
-		Window:AddLine(CmdrClient.Dispatcher:EvaluateAndRun(text, Player, { IsHuman = true }))
+		Window:AddLine(CmdrClient.Dispatcher:EvaluateAndRun(text, Player, {
+			IsHuman = true,
+			Output = function(response: string, responseColor: Color3?)
+				Window:AddLine(response, responseColor)
+			end,
+		}))
 	end
 
 	--[=[

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -334,11 +334,14 @@ end
 	@param value -- The value an implementation returned, which may or may not be a promise.
 	@param andThen -- The rest of the command.
 
-	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+	@return (Response, Color3?) -- The response, followed by the color the console should display it in.
 
 	Continues the command once the given value has settled.
 ]=]
-function Command:_settle(value: any, andThen: (Util.PromiseStatus, any) -> (any, Color3?)): (any, Color3?)
+function Command:_settle(
+	value: any,
+	andThen: (Util.PromiseStatus, any) -> (Util.Response, Color3?)
+): (Util.Response, Color3?)
 	if not Util.IsPromise(value) then
 		return andThen("Resolved", value)
 	end
@@ -355,7 +358,7 @@ function Command:_settle(value: any, andThen: (Util.PromiseStatus, any) -> (any,
 				return Util.Pending
 			end
 
-			return self:_finish(result, resultColor)
+			return self:_finish(result :: string?, resultColor)
 		end, function(err)
 			return debug.traceback(tostring(err))
 		end)
@@ -383,11 +386,11 @@ end
 	@within CommandContext
 	@private
 
-	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+	@return (Response, Color3?) -- The response, followed by the color the console should display it in.
 
 	Gathers data, then runs the implementation.
 ]=]
-function Command:_runImplementation(): (any, Color3?)
+function Command:_runImplementation(): (Util.Response, Color3?)
 	if not IS_SERVER and self.Object.Data and self.Data == nil then
 		const values, length = self:GatherArgumentValues()
 
@@ -409,11 +412,11 @@ end
 	@within CommandContext
 	@private
 
-	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+	@return (Response, Color3?) -- The response, followed by the color the console should display it in.
 
 	Runs the client implementation, falling back to the server one.
 ]=]
-function Command:_runClientImplementation(): (any, Color3?)
+function Command:_runClientImplementation(): (Util.Response, Color3?)
 	if IS_SERVER or not self.Object.ClientRun then
 		return self:_runServerImplementation()
 	end
@@ -437,11 +440,11 @@ end
 	@within CommandContext
 	@private
 
-	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+	@return (Response, Color3?) -- The response, followed by the color the console should display it in.
 
 	Runs the server implementation.
 ]=]
-function Command:_runServerImplementation(): (any, Color3?)
+function Command:_runServerImplementation(): (Util.Response, Color3?)
 	if self.Object.Run then
 		const values, length = self:GatherArgumentValues()
 
@@ -477,12 +480,12 @@ end
 
 	Records the response and runs the AfterRun hooks.
 ]=]
-function Command:_finish(response: any, responseColor: Color3?): (string?, Color3?)
+function Command:_finish(response: string?, responseColor: Color3?): (string?, Color3?)
 	self.Response = response
 
 	const afterRunHook = self.Dispatcher:RunHooks("AfterRun", self)
 	if afterRunHook then
-		return afterRunHook
+		return afterRunHook, responseColor
 	end
 
 	return self.Response, responseColor
@@ -494,7 +497,7 @@ end
 
 	Runs the command.
 ]=]
-function Command:Run(): (any, Color3?)
+function Command:Run(): (Util.Response, Color3?)
 	assert(self._Validated, "[Cmdr] Must validate a command before running.")
 
 	const beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
@@ -512,7 +515,7 @@ function Command:Run(): (any, Color3?)
 		return Util.Pending
 	end
 
-	return self:_finish(response, responseColor)
+	return self:_finish(response :: string?, responseColor)
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -1,6 +1,7 @@
 const RunService = game:GetService("RunService")
 
 const Argument = require("./Argument")
+const Util = require("./Util")
 
 const IS_SERVER = RunService:IsServer()
 const IS_CLIENT = RunService:IsClient()
@@ -290,58 +291,129 @@ function Command:GatherArgumentValues(): ({ any }, number)
 	return values, #self.ArgumentDefinitions
 end
 
+const function settle(value: any): (Util.PromiseStatus, any)
+	if not Util.IsPromise(value) then
+		return "Resolved", value
+	end
+
+	return Util.AwaitPromise(value)
+end
+
+const function failureText(status: Util.PromiseStatus, value: any): string
+	if status == "Cancelled" then
+		return "Command cancelled."
+	end
+
+	return if value == nil then "Command failed." else tostring(value)
+end
+
 --[=[
 	@within CommandContext
-	Runs the command.
+	@private
+
+	@return (string, Color3?) -- The response, followed by the color the console should display it in.
+
+	Reports an implementation whose promise didn't resolve.
 ]=]
-function Command:Run(): string?
-	assert(self._Validated, "[Cmdr] Must validate a command before running.")
+function Command:_failureResponse(status: Util.PromiseStatus, value: any): (string, Color3?)
+	const response = failureText(status, value)
 
-	const beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
-	if beforeRunHook then
-		return beforeRunHook
+	if status == "Cancelled" then
+		return response
 	end
 
-	const guardResult = self.Dispatcher:RunGuards(self)
-	if guardResult then
-		return guardResult
-	end
+	warn(`[Cmdr] {self.Name} command rejected: {response}`)
 
+	return response, Util.ErrorColor
+end
+
+--[=[
+	@within CommandContext
+	@private
+
+	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+
+	Gathers data and runs the client or server implementation, awaiting any promise they return.
+]=]
+function Command:_runImplementation(): (any, Color3?)
 	if not IS_SERVER and self.Object.Data and self.Data == nil then
 		const values, length = self:GatherArgumentValues()
-		self.Data = self.Object.Data(self, unpack(values, 1, length))
+		const status, data = settle(self.Object.Data(self, unpack(values, 1, length)))
+
+		if status ~= "Resolved" then
+			return self:_failureResponse(status, data)
+		end
+
+		self.Data = data
 	end
 
 	if not IS_SERVER and self.Object.ClientRun then
 		const values, length = self:GatherArgumentValues()
-		self.Response = self.Object.ClientRun(self, unpack(values, 1, length))
-	end
+		const status, response = settle(self.Object.ClientRun(self, unpack(values, 1, length)))
 
-	if self.Response == nil then
-		if self.Object.Run then
-			const values, length = self:GatherArgumentValues()
-			self.Response = self.Object.Run(self, unpack(values, 1, length))
-		elseif IS_SERVER then
-			if self.Object.ClientRun then
-				warn(
-					`[Cmdr] {self.Name} command fell back to the server because ClientRun returned nil, but there is no server implementation!`
-				)
-			else
-				warn(`[Cmdr] {self.Name} command has no implementation!`)
-			end
+		if status ~= "Resolved" then
+			return self:_failureResponse(status, response)
+		end
 
-			self.Response = "No implementation."
-		else
-			self.Response = self.Dispatcher:Send(self.RawText, self.Data)
+		if response ~= nil then
+			return response
 		end
 	end
+
+	if self.Object.Run then
+		const values, length = self:GatherArgumentValues()
+		const status, response = settle(self.Object.Run(self, unpack(values, 1, length)))
+
+		if status ~= "Resolved" then
+			return self:_failureResponse(status, response)
+		end
+
+		return response
+	end
+
+	if IS_SERVER then
+		if self.Object.ClientRun then
+			warn(
+				`[Cmdr] {self.Name} command fell back to the server because ClientRun returned nil, but there is no server implementation!`
+			)
+		else
+			warn(`[Cmdr] {self.Name} command has no implementation!`)
+		end
+
+		return "No implementation."
+	end
+
+	return self.Dispatcher:Send(self.RawText, self.Data)
+end
+
+--[=[
+	@within CommandContext
+	@return (string?, Color3?) -- The response, followed by the color the console should display it in.
+
+	Runs the command.
+]=]
+function Command:Run(): (string?, Color3?)
+	assert(self._Validated, "[Cmdr] Must validate a command before running.")
+
+	const beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
+	if beforeRunHook then
+		return beforeRunHook, Util.ErrorColor
+	end
+
+	const guardResult = self.Dispatcher:RunGuards(self)
+	if guardResult then
+		return guardResult, Util.ErrorColor
+	end
+
+	const response, responseColor = self:_runImplementation()
+	self.Response = response
 
 	const afterRunHook = self.Dispatcher:RunHooks("AfterRun", self)
 	if afterRunHook then
 		return afterRunHook
 	end
 
-	return self.Response
+	return self.Response, responseColor
 end
 
 --[=[
@@ -366,7 +438,13 @@ function Command:GetData()
 	end
 
 	if self.Object.Data and not IS_SERVER then
-		self.Data = self.Object.Data(self)
+		const status, data = settle(self.Object.Data(self))
+
+		if status ~= "Resolved" then
+			error(failureText(status, data), 0)
+		end
+
+		self.Data = data
 	end
 
 	return self.Data

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -331,26 +331,88 @@ end
 	@within CommandContext
 	@private
 
+	@param value -- The value an implementation returned, which may or may not be a promise.
+	@param continue -- The rest of the command.
+
 	@return (any, Color3?) -- The response, followed by the color the console should display it in.
 
-	Gathers data and runs the client or server implementation, awaiting any promise they return.
+	Continues the command once the given value has settled.
+]=]
+function Command:_settle(value: any, continue: (Util.PromiseStatus, any) -> (any, Color3?)): (any, Color3?)
+	if not Util.IsPromise(value) then
+		return continue("Resolved", value)
+	end
+
+	if not self._output then
+		return continue(settle(value))
+	end
+
+	task.spawn(function()
+		const success, response, responseColor = xpcall(continue, function(err)
+			return debug.traceback(tostring(err))
+		end, Util.AwaitPromise(value))
+
+		if not success then
+			warn(`[Cmdr] Error occurred while running the {self.Name} command\n{response}`)
+			self._output(
+				"An error occurred while running this command. Check the console for more information.",
+				Util.ErrorColor
+			)
+			return
+		end
+
+		if response == Util.Pending then
+			return
+		end
+
+		self._output(self:_finish(response, responseColor))
+	end)
+
+	return Util.Pending
+end
+
+--[=[
+	@within CommandContext
+	@private
+
+	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+
+	Gathers data, then runs the implementation.
 ]=]
 function Command:_runImplementation(): (any, Color3?)
 	if not IS_SERVER and self.Object.Data and self.Data == nil then
 		const values, length = self:GatherArgumentValues()
-		const status, data = settle(self.Object.Data(self, unpack(values, 1, length)))
 
-		if status ~= "Resolved" then
-			return self:_failureResponse(status, data)
-		end
+		return self:_settle(self.Object.Data(self, unpack(values, 1, length)), function(status, data)
+			if status ~= "Resolved" then
+				return self:_failureResponse(status, data)
+			end
 
-		self.Data = data
+			self.Data = data
+
+			return self:_runClientImplementation()
+		end)
 	end
 
-	if not IS_SERVER and self.Object.ClientRun then
-		const values, length = self:GatherArgumentValues()
-		const status, response = settle(self.Object.ClientRun(self, unpack(values, 1, length)))
+	return self:_runClientImplementation()
+end
 
+--[=[
+	@within CommandContext
+	@private
+
+	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+
+	Runs the client implementation, falling back to the server one.
+]=]
+function Command:_runClientImplementation(): (any, Color3?)
+	if IS_SERVER or not self.Object.ClientRun then
+		return self:_runServerImplementation()
+	end
+
+	const values, length = self:GatherArgumentValues()
+
+	return self:_settle(self.Object.ClientRun(self, unpack(values, 1, length)), function(status, response)
 		if status ~= "Resolved" then
 			return self:_failureResponse(status, response)
 		end
@@ -358,17 +420,30 @@ function Command:_runImplementation(): (any, Color3?)
 		if response ~= nil then
 			return response
 		end
-	end
 
+		return self:_runServerImplementation()
+	end)
+end
+
+--[=[
+	@within CommandContext
+	@private
+
+	@return (any, Color3?) -- The response, followed by the color the console should display it in.
+
+	Runs the server implementation.
+]=]
+function Command:_runServerImplementation(): (any, Color3?)
 	if self.Object.Run then
 		const values, length = self:GatherArgumentValues()
-		const status, response = settle(self.Object.Run(self, unpack(values, 1, length)))
 
-		if status ~= "Resolved" then
-			return self:_failureResponse(status, response)
-		end
+		return self:_settle(self.Object.Run(self, unpack(values, 1, length)), function(status, response)
+			if status ~= "Resolved" then
+				return self:_failureResponse(status, response)
+			end
 
-		return response
+			return response
+		end)
 	end
 
 	if IS_SERVER then
@@ -383,16 +458,35 @@ function Command:_runImplementation(): (any, Color3?)
 		return "No implementation."
 	end
 
-	return self.Dispatcher:Send(self.RawText, self.Data)
+	return self.Dispatcher:Send(self.RawText, self.Data, self._output ~= nil)
 end
 
 --[=[
 	@within CommandContext
+	@private
+
 	@return (string?, Color3?) -- The response, followed by the color the console should display it in.
+
+	Records the response and runs the AfterRun hooks.
+]=]
+function Command:_finish(response: any, responseColor: Color3?): (string?, Color3?)
+	self.Response = response
+
+	const afterRunHook = self.Dispatcher:RunHooks("AfterRun", self)
+	if afterRunHook then
+		return afterRunHook
+	end
+
+	return self.Response, responseColor
+end
+
+--[=[
+	@within CommandContext
+	@return (string? | Pending, Color3?) -- The response, followed by the color the console should display it in. [Util.Pending] means the response will be given to the command's output callback instead.
 
 	Runs the command.
 ]=]
-function Command:Run(): (string?, Color3?)
+function Command:Run(): (any, Color3?)
 	assert(self._Validated, "[Cmdr] Must validate a command before running.")
 
 	const beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
@@ -406,14 +500,11 @@ function Command:Run(): (string?, Color3?)
 	end
 
 	const response, responseColor = self:_runImplementation()
-	self.Response = response
-
-	const afterRunHook = self.Dispatcher:RunHooks("AfterRun", self)
-	if afterRunHook then
-		return afterRunHook
+	if response == Util.Pending then
+		return Util.Pending
 	end
 
-	return self.Response, responseColor
+	return self:_finish(response, responseColor)
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -332,23 +332,23 @@ end
 	@private
 
 	@param value -- The value an implementation returned, which may or may not be a promise.
-	@param continue -- The rest of the command.
+	@param andThen -- The rest of the command.
 
 	@return (any, Color3?) -- The response, followed by the color the console should display it in.
 
 	Continues the command once the given value has settled.
 ]=]
-function Command:_settle(value: any, continue: (Util.PromiseStatus, any) -> (any, Color3?)): (any, Color3?)
+function Command:_settle(value: any, andThen: (Util.PromiseStatus, any) -> (any, Color3?)): (any, Color3?)
 	if not Util.IsPromise(value) then
-		return continue("Resolved", value)
+		return andThen("Resolved", value)
 	end
 
 	if not self._output then
-		return continue(settle(value))
+		return andThen(settle(value))
 	end
 
 	task.spawn(function()
-		const success, response, responseColor = xpcall(continue, function(err)
+		const success, response, responseColor = xpcall(andThen, function(err)
 			return debug.traceback(tostring(err))
 		end, Util.AwaitPromise(value))
 

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -348,9 +348,17 @@ function Command:_settle(value: any, andThen: (Util.PromiseStatus, any) -> (any,
 	end
 
 	task.spawn(function()
-		const success, response, responseColor = xpcall(andThen, function(err)
+		const success, response, responseColor = xpcall(function()
+			const result, resultColor = andThen(Util.AwaitPromise(value))
+
+			if result == Util.Pending then
+				return Util.Pending
+			end
+
+			return self:_finish(result, resultColor)
+		end, function(err)
 			return debug.traceback(tostring(err))
-		end, Util.AwaitPromise(value))
+		end)
 
 		if not success then
 			warn(`[Cmdr] Error occurred while running the {self.Name} command\n{response}`)
@@ -365,7 +373,7 @@ function Command:_settle(value: any, andThen: (Util.PromiseStatus, any) -> (any,
 			return
 		end
 
-		self._output(self:_finish(response, responseColor))
+		self._output(response, responseColor)
 	end)
 
 	return Util.Pending

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -307,6 +307,10 @@ const function failureText(status: Util.PromiseStatus, value: any): string
 	return if value == nil then "Command failed." else tostring(value)
 end
 
+const function isExecutionError(value: any): boolean
+	return type(value) == "table" and (value :: any).kind == "ExecutionError" and type((value :: any).trace) == "string"
+end
+
 --[=[
 	@within CommandContext
 	@private
@@ -316,13 +320,17 @@ end
 	Reports an implementation whose promise didn't resolve.
 ]=]
 function Command:_failureResponse(status: Util.PromiseStatus, value: any): (string, Color3?)
-	const response = failureText(status, value)
-
 	if status == "Cancelled" then
-		return response
+		return failureText(status, value)
 	end
 
-	warn(`[Cmdr] {self.Name} command rejected: {response}`)
+	if isExecutionError(value) then
+		warn(`[Cmdr] Error occurred while running the {self.Name} command\n{tostring(value)}`)
+		return "An error occurred while running this command. Check the console for more information.", Util.ErrorColor
+	end
+
+	const response = failureText(status, value)
+	warn(`[Cmdr] Error occurred while running the {self.Name} command\n{response}`)
 
 	return response, Util.ErrorColor
 end

--- a/Cmdr/CmdrClient/Shared/Command.luau
+++ b/Cmdr/CmdrClient/Shared/Command.luau
@@ -460,7 +460,7 @@ function Command:_runServerImplementation(): (Util.Response, Color3?)
 	if IS_SERVER then
 		if self.Object.ClientRun then
 			warn(
-				`[Cmdr] {self.Name} command fell back to the server because ClientRun returned nil, but there is no server implementation!`
+				`[Cmdr] {self.Name} command fell back to the server because ClientRun returned nil, but there is no server implementation.`
 			)
 		else
 			warn(`[Cmdr] {self.Name} command has no implementation!`)
@@ -498,7 +498,7 @@ end
 	Runs the command.
 ]=]
 function Command:Run(): (Util.Response, Color3?)
-	assert(self._Validated, "[Cmdr] Must validate a command before running.")
+	assert(self._Validated, "[Cmdr] CommandContext must be validated before running.")
 
 	const beforeRunHook = self.Dispatcher:RunHooks("BeforeRun", self)
 	if beforeRunHook then

--- a/Cmdr/CmdrClient/Shared/Dispatcher.luau
+++ b/Cmdr/CmdrClient/Shared/Dispatcher.luau
@@ -104,6 +104,8 @@ end
 	Runs a command as the given player. Executor is optional when running on the client.
 	If `options.Data` is given, it will be available on the server with CommandContext.GetData
 	If `options.IsHuman` is true and this function is called on the client, then the `text` will be inserted into the window history.
+
+	Returns the command response, followed by the color the console should display it in.
 ]=]
 function Dispatcher:EvaluateAndRun(
 	text: string,
@@ -112,7 +114,7 @@ function Dispatcher:EvaluateAndRun(
 		Data: any?,
 		IsHuman: boolean?,
 	}?
-): string
+): (string, Color3?)
 	executor = executor or Players.LocalPlayer
 	options = options or {}
 
@@ -122,27 +124,29 @@ function Dispatcher:EvaluateAndRun(
 
 	const commandContext, errorText = self:Evaluate(text, executor, nil, (options :: any).Data)
 	if not commandContext then
-		return errorText
+		return errorText, Util.ErrorColor
 	end
 
-	const success, result = xpcall(function()
+	const success, result, resultColor = xpcall(function()
 		const isValid, validationError = commandContext:Validate(true)
 
 		if not isValid then
-			return validationError
+			return validationError, Util.ErrorColor
 		end
 
-		return commandContext:Run() or "Command executed."
+		const response, responseColor = commandContext:Run()
+
+		return response or "Command executed.", responseColor
 	end, function(err)
 		return debug.traceback(tostring(err))
 	end)
 
 	if not success then
 		warn(`[Cmdr] Error occurred while evaluating command string {("%q"):format(text)}\n{result}`)
-		return "An error occurred while running this command. Check the console for more information."
+		return "An error occurred while running this command. Check the console for more information.", Util.ErrorColor
 	end
 
-	return result
+	return result, resultColor
 end
 
 --[=[
@@ -151,8 +155,10 @@ end
 	@client
 
 	Send text as the local user to remote server to be evaluated there.
+
+	Returns the command response, followed by the color the console should display it in.
 ]=]
-function Dispatcher:Send(text: string, data: any?): string
+function Dispatcher:Send(text: string, data: any?): (string, Color3?)
 	assert(IS_CLIENT, "[Cmdr] [Dispatcher::Send] can only be called from the client.")
 	return self.Cmdr._remoteFunction:InvokeServer(text, { Data = data })
 end
@@ -209,7 +215,7 @@ function Dispatcher:Run(...: any): string
 	const valid, validationError = commandContext:Validate(true)
 	assert(valid, validationError)
 
-	return commandContext:Run()
+	return (commandContext:Run())
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Dispatcher.luau
+++ b/Cmdr/CmdrClient/Shared/Dispatcher.luau
@@ -104,6 +104,7 @@ end
 	Runs a command as the given player. Executor is optional when running on the client.
 	If `options.Data` is given, it will be available on the server with CommandContext.GetData
 	If `options.IsHuman` is true and this function is called on the client, then the `text` will be inserted into the window history.
+	If `options.Output` is given, a command waiting on a promise responds with an empty string and gives its real response to `options.Output` once the promise settles.
 
 	Returns the command response, followed by the color the console should display it in.
 ]=]
@@ -113,6 +114,7 @@ function Dispatcher:EvaluateAndRun(
 	options: {
 		Data: any?,
 		IsHuman: boolean?,
+		Output: ((response: string, responseColor: Color3?) -> ())?,
 	}?
 ): (string, Color3?)
 	executor = executor or Players.LocalPlayer
@@ -127,6 +129,13 @@ function Dispatcher:EvaluateAndRun(
 		return errorText, Util.ErrorColor
 	end
 
+	const output = (options :: any).Output
+	if output then
+		commandContext._output = function(response: string?, responseColor: Color3?)
+			output(response or "Command executed.", responseColor)
+		end
+	end
+
 	const success, result, resultColor = xpcall(function()
 		const isValid, validationError = commandContext:Validate(true)
 
@@ -135,6 +144,10 @@ function Dispatcher:EvaluateAndRun(
 		end
 
 		const response, responseColor = commandContext:Run()
+
+		if response == Util.Pending then
+			return ""
+		end
 
 		return response or "Command executed.", responseColor
 	end, function(err)
@@ -156,11 +169,13 @@ end
 
 	Send text as the local user to remote server to be evaluated there.
 
+	When `defer` is true, a server implementation waiting on a promise responds with an empty string and sends its real response to the console later.
+
 	Returns the command response, followed by the color the console should display it in.
 ]=]
-function Dispatcher:Send(text: string, data: any?): (string, Color3?)
+function Dispatcher:Send(text: string, data: any?, defer: boolean?): (string, Color3?)
 	assert(IS_CLIENT, "[Cmdr] [Dispatcher::Send] can only be called from the client.")
-	return self.Cmdr._remoteFunction:InvokeServer(text, { Data = data })
+	return self.Cmdr._remoteFunction:InvokeServer(text, { Data = data, Defer = defer })
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Dispatcher.luau
+++ b/Cmdr/CmdrClient/Shared/Dispatcher.luau
@@ -149,7 +149,7 @@ function Dispatcher:EvaluateAndRun(
 			return ""
 		end
 
-		return response or "Command executed.", responseColor
+		return (response :: string?) or "Command executed.", responseColor
 	end, function(err)
 		return debug.traceback(tostring(err))
 	end)
@@ -212,16 +212,16 @@ end
 	@client
 
 	Invokes a command programmatically as the local player.
-	Accepts a variable number of arguments, which are all joined with spaces before being run; the command should be the first argument.
+	Accepts the command name, followed by a variable number of arguments which are all joined with spaces before being run.
 	This function will raise an error if any validations occur, since it's only for hard-coded (or generated) commands.
 ]=]
-function Dispatcher:Run(...: any): string
+function Dispatcher:Run(command: string, ...: unknown): string?
 	assert(IS_CLIENT, "[Cmdr] [Dispatcher::Run] can only be called from the client.")
 
 	const arguments = { ... }
-	local text = tostring(arguments[1])
-	for index = 2, #arguments do
-		text ..= ` {arguments[index]}`
+	local text = tostring(command)
+	for index = 1, #arguments do
+		text ..= ` {tostring(arguments[index])}`
 	end
 
 	const commandContext, errorText = self:Evaluate(text, Players.LocalPlayer)
@@ -230,7 +230,7 @@ function Dispatcher:Run(...: any): string
 	const valid, validationError = commandContext:Validate(true)
 	assert(valid, validationError)
 
-	return (commandContext:Run())
+	return (commandContext:Run()) :: string?
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -120,7 +120,7 @@ end
 
 	@prop Pending Pending
 
-	The response of a command whose real response will be given to its output callback later. See [Dispatcher:EvaluateAndRun].
+	A symbol representing a placeholder command response; the real response will be given to its output callback later. See [Dispatcher:EvaluateAndRun].
 ]=]
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -87,9 +87,31 @@ const function quoteString(value: string): string
 	return ("%q"):format(value)
 end
 
+const function isCallable(value: any): boolean
+	if type(value) == "function" then
+		return true
+	end
+
+	if type(value) == "table" then
+		const metatable = getmetatable(value)
+		return type(metatable) == "table" and rawget(metatable, "__call") ~= nil
+	end
+
+	return false
+end
+
 --[=[
 	@class Util
 	Cmdr utilities module.
+]=]
+
+--[=[
+	@within Util
+	@readonly
+
+	@prop ErrorColor Color3
+
+	The color the console displays a failed command in.
 ]=]
 
 --[=[
@@ -103,6 +125,7 @@ end
 ]=]
 
 const Util = {
+	ErrorColor = Color3.fromRGB(255, 153, 153),
 	_deprecationWarnings = {} :: { [string]: { Description: string, Suppressed: boolean, Emitted: boolean } },
 }
 
@@ -808,6 +831,76 @@ function Util.Mutex(): () -> ()
 			end
 		end
 	end
+end
+
+export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
+
+--[=[
+	@within Util
+	@param value any
+
+	Returns whether the value looks like a promise, using the same duck typing as [evaera's Promise library](https://eryn.io/roblox-lua-promise/api/Promise#is).
+]=]
+function Util.IsPromise(value: any): boolean
+	if type(value) ~= "table" then
+		return false
+	end
+
+	if isCallable(rawget(value, "andThen")) then
+		return true
+	end
+
+	const metatable = getmetatable(value)
+	const index = if type(metatable) == "table" then rawget(metatable, "__index") else nil
+
+	return type(index) == "table" and isCallable(rawget(index, "andThen"))
+end
+
+--[=[
+	@within Util
+	@param promise Promise
+	@return (PromiseStatus, any) -- The status the promise settled with, followed by the value it settled with.
+
+	Yields until the given promise settles.
+]=]
+function Util.AwaitPromise(promise: any): (PromiseStatus, any)
+	local status: PromiseStatus?, value: any
+	const thread = coroutine.running()
+
+	const function settle(settledStatus: PromiseStatus)
+		return function(...)
+			if status then
+				return
+			end
+
+			status, value = settledStatus, (...)
+
+			if coroutine.status(thread) == "suspended" then
+				task.spawn(thread)
+			end
+		end
+	end
+
+	promise:andThen(settle("Resolved"), settle("Rejected"))
+	if not status and isCallable(promise.finally) then
+		const settleCancellation = settle("Cancelled")
+		const settlement = promise:finally(function(finallyStatus: any)
+			if finallyStatus == "Cancelled" or finallyStatus == nil then
+				settleCancellation()
+			end
+		end)
+
+		if type(settlement) == "table" and isCallable(settlement.catch) then
+			settlement:catch(function() end)
+		end
+	end
+
+	-- To prevent external resumes
+	while not status do
+		coroutine.yield()
+	end
+
+	return status :: PromiseStatus, value
 end
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -117,6 +117,15 @@ end
 --[=[
 	@within Util
 	@readonly
+
+	@prop Pending Pending
+
+	The response of a command whose real response will be given to its output callback later. See [Dispatcher:EvaluateAndRun].
+]=]
+
+--[=[
+	@within Util
+	@readonly
 	@private
 
 	@prop _deprecationWarnings { [string]: { Description: string, Suppressed: boolean, Emitted: boolean } }
@@ -126,6 +135,7 @@ end
 
 const Util = {
 	ErrorColor = Color3.fromRGB(255, 153, 153),
+	Pending = table.freeze({}) :: Pending,
 	_deprecationWarnings = {} :: { [string]: { Description: string, Suppressed: boolean, Emitted: boolean } },
 }
 
@@ -832,6 +842,8 @@ function Util.Mutex(): () -> ()
 		end
 	end
 end
+
+export type Pending = {}
 
 export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
 

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -843,10 +843,28 @@ function Util.Mutex(): () -> ()
 	end
 end
 
+--[=[
+	@within Util
+	@type Pending {}
+
+	The type of [Util.Pending], the response of a command whose real response will be given to its output callback later.
+]=]
 export type Pending = {}
 
+--[=[
+	@within Util
+	@type Response string? | Pending
+
+	Anything a command implementation may return as its response.
+]=]
 export type Response = string? | Pending
 
+--[=[
+	@within Util
+	@type PromiseStatus "Resolved" | "Rejected" | "Cancelled"
+
+	The states a promise can settle in, mirroring [evaera's Promise.Status](https://eryn.io/roblox-lua-promise/api/Promise#Status) minus `Started`.
+]=]
 export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
 
 --[=[

--- a/Cmdr/CmdrClient/Shared/Util.luau
+++ b/Cmdr/CmdrClient/Shared/Util.luau
@@ -845,6 +845,8 @@ end
 
 export type Pending = {}
 
+export type Response = string? | Pending
+
 export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
 
 --[=[

--- a/Cmdr/init.luau
+++ b/Cmdr/init.luau
@@ -141,7 +141,7 @@ const function initialize()
 
 	Cmdr._remoteFunction.OnServerInvoke = function(player: Player, text: string, options: any)
 		if #text > 10000 then
-			return "Input too long"
+			return "Input too long", Util.ErrorColor
 		end
 
 		return Cmdr.Dispatcher:EvaluateAndRun(text, player, options)

--- a/Cmdr/init.luau
+++ b/Cmdr/init.luau
@@ -144,7 +144,16 @@ const function initialize()
 			return "Input too long", Util.ErrorColor
 		end
 
-		return Cmdr.Dispatcher:EvaluateAndRun(text, player, options)
+		const clientOptions = if type(options) == "table" then options else {}
+
+		return Cmdr.Dispatcher:EvaluateAndRun(text, player, {
+			Data = clientOptions.Data,
+			Output = if clientOptions.Defer == true
+				then function(response: string, responseColor: Color3?)
+					Cmdr.Dispatcher:SendEvent(player, "AddLine", response, responseColor)
+				end
+				else nil,
+		})
 	end
 
 	Cmdr.Registry:RegisterTypesIn(Cmdr._defaultTypesFolder)

--- a/docs/04-commands.md
+++ b/docs/04-commands.md
@@ -71,7 +71,31 @@ If you want your command to run on the client, you can add a [`ClientRun`](/api/
 If using `ClientRun`, having a Server module associated with this command is optional. If your `ClientRun` function returns a string, the command will run entirely on the client and won't touch the server at all (which means server-only hooks won't run). If this function doesn't return anything, it will then execute the associated Server module implementation on the server (including any server-sided hooks).
 
 :::caution
-If the `ClientRun` function is present and there isn't a Server module for this command then you must return a string from the `ClientRun` function.
+If the `ClientRun` function is present and there isn't a Server module for this command then you must return a string from the `ClientRun` function, or a promise that resolves to one.
+:::
+
+## Asynchronous commands
+
+Command implementations are allowed to yield, so most asynchronous work needs nothing special. If you prefer promises, your server implementation, `ClientRun` and `Data` may also return one, and Cmdr will wait for it to settle before continuing.
+
+```luau title="FetchServer.luau"
+return function(context: any, userId: number)
+	return getProfileAsync(userId):andThen(function(profile)
+		return `{profile.Name} has {profile.Coins} coins.`
+	end)
+end
+```
+
+Any object with an `andThen` method is treated as a promise, which covers [evaera's Promise library](https://eryn.io/roblox-lua-promise/) and anything compatible with it.
+
+- **Resolved** values are used as the command's response, exactly as if they had been returned directly. A `ClientRun` promise that resolves to `nil` falls back to the server, just like returning `nil` does.
+- **Rejected** promises use the rejection value as the response and emit a warning, so a rejection you don't handle yourself won't disappear silently. When the command was run from the console, the response is printed in the same color as any other command error.
+- **Cancelled** promises respond with `Command cancelled.` as ordinary output and emit no warning.
+
+Either way the command counts as having run, so your `AfterRun` hooks still fire and can rewrite the response.
+
+:::caution
+The console waits for the promise, so a promise that never settles leaves the command hanging. Use [`Promise:timeout`](https://eryn.io/roblox-lua-promise/api/Promise#timeout) if that's a possibility.
 :::
 
 ## Execution order

--- a/docs/04-commands.md
+++ b/docs/04-commands.md
@@ -76,7 +76,7 @@ If the `ClientRun` function is present and there isn't a Server module for this 
 
 ## Asynchronous commands
 
-Command implementations are allowed to yield, so most asynchronous work needs nothing special. If you prefer promises, your server implementation, `ClientRun` and `Data` may also return one, and Cmdr will wait for it to settle before continuing.
+Command implementations are allowed to yield, so most asynchronous work needs nothing special. If you prefer promises, your server implementation, `ClientRun` and `Data` may also return one, and Cmdr will continue the command once it settles.
 
 ```luau title="FetchServer.luau"
 return function(context: any, userId: number)
@@ -88,15 +88,19 @@ end
 
 Any object with an `andThen` method is treated as a promise, which covers [evaera's Promise library](https://eryn.io/roblox-lua-promise/) and anything compatible with it.
 
-- **Resolved** values are used as the command's response, exactly as if they had been returned directly. A `ClientRun` promise that resolves to `nil` falls back to the server, just like returning `nil` does.
-- **Rejected** promises use the rejection value as the response and emit a warning, so a rejection you don't handle yourself won't disappear silently. When the command was run from the console, the response is printed in the same color as any other command error.
-- **Cancelled** promises respond with `Command cancelled.` as ordinary output and emit no warning.
+- **Resolved** values are the command's response, exactly as if they had been returned directly, so a `ClientRun` promise resolving to `nil` falls back to the server.
+- **Rejected** promises respond with the rejection value, in the console's error color, and emit a warning.
+- **Cancelled** promises respond with `Command cancelled.`
 
 Either way the command counts as having run, so your `AfterRun` hooks still fire and can rewrite the response.
 
-:::caution
-The console waits for the promise, so a promise that never settles leaves the command hanging. Use [`Promise:timeout`](https://eryn.io/roblox-lua-promise/api/Promise#timeout) if that's a possibility.
-:::
+### Waiting doesn't block the console
+
+The console stays usable while a promise is outstanding, so more commands can be run in the meantime. Responses are printed as their promises settle, which means they can appear out of order.
+
+A response from a server implementation's promise arrives as a console message rather than as the command's response, so client-side `AfterRun` hooks don't see it.
+
+Commands run programmatically with [`Dispatcher:Run`](/api/Dispatcher#Run) or [`Dispatcher:EvaluateAndRun`](/api/Dispatcher#EvaluateAndRun) wait for the promise instead, since they have to return the response.
 
 ## Execution order
 

--- a/docs/04-commands.md
+++ b/docs/04-commands.md
@@ -74,9 +74,9 @@ If using `ClientRun`, having a Server module associated with this command is opt
 If the `ClientRun` function is present and there isn't a Server module for this command then you must return a string from the `ClientRun` function, or a promise that resolves to one.
 :::
 
-## Asynchronous commands
+## Promises
 
-Command implementations are allowed to yield, so most asynchronous work needs nothing special. If you prefer promises, your server implementation, `ClientRun` and `Data` may also return one, and Cmdr will continue the command once it settles.
+Command implementations are allowed to yield, so you don't need to do anything for asynchronous work. Server implementation, `ClientRun`, and `Data` can return promises and Cmdr will continue the command once it settles.
 
 ```luau title="FetchServer.luau"
 return function(context: any, userId: number)
@@ -92,7 +92,7 @@ Any object with an `andThen` method is treated as a promise, which covers [evaer
 - **Rejected** promises respond with the rejection value, in the console's error color, and emit a warning.
 - **Cancelled** promises respond with `Command cancelled.`
 
-Either way the command counts as having run, so your `AfterRun` hooks still fire and can rewrite the response.
+Either way the command counts as having run, so `AfterRun` hooks fire and can rewrite the response.
 
 ### Waiting doesn't block the console
 

--- a/docs/04-commands.md
+++ b/docs/04-commands.md
@@ -90,6 +90,7 @@ Any object with an `andThen` method is treated as a promise, which covers [evaer
 
 - **Resolved** values are the command's response, exactly as if they had been returned directly, so a `ClientRun` promise resolving to `nil` falls back to the server.
 - **Rejected** promises respond with the rejection value, in the console's error color, and emit a warning.
+  - When the rejection carries a traceback from an error thrown inside the promise, the warning uses that instead, and the console responds with a generic message, matching how an error in an ordinary command is reported.
 - **Cancelled** promises respond with `Command cancelled.`
 
 Either way the command counts as having run, so `AfterRun` hooks fire and can rewrite the response.

--- a/docs/80-cookbook.md
+++ b/docs/80-cookbook.md
@@ -274,7 +274,7 @@ export type CommandContext = {
 	Validate: (self: CommandContext, isFinal: boolean?) -> (boolean, string),
 	GetLastArgument: (self: CommandContext) -> ArgumentContext?,
 	GatherArgumentValues: (self: CommandContext) -> ({ any }, number),
-	Run: (self: CommandContext) -> (string?, Color3?),
+	Run: (self: CommandContext) -> (string? | Pending, Color3?),
 	GetArgument: (self: CommandContext, index: number) -> ArgumentContext?,
 	GetData: (self: CommandContext) -> any,
 	SendEvent: (self: CommandContext, player: Player, event: string, ...any) -> (),
@@ -336,9 +336,13 @@ export type Dispatcher = {
 		self: Dispatcher,
 		text: string,
 		executor: Player?,
-		options: { Data: any?, IsHuman: boolean? }?
+		options: {
+			Data: any?,
+			IsHuman: boolean?,
+			Output: ((response: string, responseColor: Color3?) -> ())?,
+		}?
 	) -> (string, Color3?),
-	Send: (self: Dispatcher, text: string, data: any?) -> (string, Color3?),
+	Send: (self: Dispatcher, text: string, data: any?, defer: boolean?) -> (string, Color3?),
 	SendEvent: (self: Dispatcher, player: Player, event: string, ...any) -> (),
 	BroadcastEvent: (self: Dispatcher, event: string, ...any) -> (),
 	Run: (self: Dispatcher, ...any) -> string,
@@ -348,10 +352,13 @@ export type Dispatcher = {
 
 export type FuzzyFinder = (text: string, returnFirst: boolean?, matchStart: boolean?) -> any
 
+export type Pending = {}
+
 export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
 
 export type Util = {
 	ErrorColor: Color3,
+	Pending: Pending,
 	MakeDictionary: (array: { any }) -> { [any]: true },
 	DictionaryKeys: (dict: { [any]: any }) -> { any },
 	MakeFuzzyFinder: (setOrContainer: any) -> FuzzyFinder,

--- a/docs/80-cookbook.md
+++ b/docs/80-cookbook.md
@@ -241,8 +241,8 @@ export type CommandDefinition = {
 	Group: string?,
 	Args: { ArgumentDefinition | (CommandContext) -> ArgumentDefinition? },
 	Data: ((CommandContext, ...any) -> any)?,
-	ClientRun: ((CommandContext, ...any) -> string?)?,
-	Run: ((CommandContext, ...any) -> string?)?,
+	ClientRun: ((CommandContext, ...any) -> any)?,
+	Run: ((CommandContext, ...any) -> any)?,
 	Guards: { (CommandContext, ...any) -> string? }?,
 	AutoExec: { string }?,
 
@@ -274,7 +274,7 @@ export type CommandContext = {
 	Validate: (self: CommandContext, isFinal: boolean?) -> (boolean, string),
 	GetLastArgument: (self: CommandContext) -> ArgumentContext?,
 	GatherArgumentValues: (self: CommandContext) -> ({ any }, number),
-	Run: (self: CommandContext) -> string?,
+	Run: (self: CommandContext) -> (string?, Color3?),
 	GetArgument: (self: CommandContext, index: number) -> ArgumentContext?,
 	GetData: (self: CommandContext) -> any,
 	SendEvent: (self: CommandContext, player: Player, event: string, ...any) -> (),
@@ -337,8 +337,8 @@ export type Dispatcher = {
 		text: string,
 		executor: Player?,
 		options: { Data: any?, IsHuman: boolean? }?
-	) -> string,
-	Send: (self: Dispatcher, text: string, data: any?) -> string,
+	) -> (string, Color3?),
+	Send: (self: Dispatcher, text: string, data: any?) -> (string, Color3?),
 	SendEvent: (self: Dispatcher, player: Player, event: string, ...any) -> (),
 	BroadcastEvent: (self: Dispatcher, event: string, ...any) -> (),
 	Run: (self: Dispatcher, ...any) -> string,
@@ -348,7 +348,10 @@ export type Dispatcher = {
 
 export type FuzzyFinder = (text: string, returnFirst: boolean?, matchStart: boolean?) -> any
 
+export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
+
 export type Util = {
+	ErrorColor: Color3,
 	MakeDictionary: (array: { any }) -> { [any]: true },
 	DictionaryKeys: (dict: { [any]: any }) -> { any },
 	MakeFuzzyFinder: (setOrContainer: any) -> FuzzyFinder,
@@ -365,6 +368,8 @@ export type Util = {
 	RunEmbeddedCommands: (dispatcher: Dispatcher, str: string) -> string,
 	SubstituteArgs: (str: string, replace: any) -> string,
 	MakeAliasCommand: (name: string, commandString: string) -> CommandDefinition,
+	IsPromise: (value: any) -> boolean,
+	AwaitPromise: (promise: any) -> (PromiseStatus, any),
 	Map: <T, U>(array: { T }, callback: (T, number) -> U) -> { U },
 	Each: (callback: (any) -> any, ...any) -> ...any,
 

--- a/docs/80-cookbook.md
+++ b/docs/80-cookbook.md
@@ -274,7 +274,7 @@ export type CommandContext = {
 	Validate: (self: CommandContext, isFinal: boolean?) -> (boolean, string),
 	GetLastArgument: (self: CommandContext) -> ArgumentContext?,
 	GatherArgumentValues: (self: CommandContext) -> ({ any }, number),
-	Run: (self: CommandContext) -> (string? | Pending, Color3?),
+	Run: (self: CommandContext) -> (Response, Color3?),
 	GetArgument: (self: CommandContext, index: number) -> ArgumentContext?,
 	GetData: (self: CommandContext) -> any,
 	SendEvent: (self: CommandContext, player: Player, event: string, ...any) -> (),
@@ -345,7 +345,7 @@ export type Dispatcher = {
 	Send: (self: Dispatcher, text: string, data: any?, defer: boolean?) -> (string, Color3?),
 	SendEvent: (self: Dispatcher, player: Player, event: string, ...any) -> (),
 	BroadcastEvent: (self: Dispatcher, event: string, ...any) -> (),
-	Run: (self: Dispatcher, ...any) -> string,
+	Run: (self: Dispatcher, command: string, ...unknown) -> string?,
 	GetHistory: (self: Dispatcher) -> { string },
 	RunBeforeCommandRegisterHooks: (self: Dispatcher, player: Player?) -> (),
 }
@@ -353,6 +353,8 @@ export type Dispatcher = {
 export type FuzzyFinder = (text: string, returnFirst: boolean?, matchStart: boolean?) -> any
 
 export type Pending = {}
+
+export type Response = string? | Pending
 
 export type PromiseStatus = "Resolved" | "Rejected" | "Cancelled"
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,11 +1,11 @@
 [package]
-name = "sqikerz/cmdr"
+name = "evaera/cmdr"
 description = "A fully extensible, type-safe command framework for Roblox."
-version = "1.13.1"
+version = "1.13.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 homepage = "https://eryn.io/Cmdr/"
-repository = "https://github.com/sqikerz/Cmdr"
+repository = "https://github.com/evaera/Cmdr"
 realm = "shared"
 exclude = ["**"]
 include = [

--- a/wally.toml
+++ b/wally.toml
@@ -1,11 +1,11 @@
 [package]
-name = "evaera/cmdr"
+name = "sqikerz/cmdr"
 description = "A fully extensible, type-safe command framework for Roblox."
-version = "1.13.0"
+version = "1.13.1"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 homepage = "https://eryn.io/Cmdr/"
-repository = "https://github.com/evaera/Cmdr"
+repository = "https://github.com/sqikerz/Cmdr"
 realm = "shared"
 exclude = ["**"]
 include = [


### PR DESCRIPTION
Closes #108

Commands can now return a promise from their server implementation, `ClientRun`, or `Data`, and Cmdr continues the command once it settles. Anything with an `andThen` method counts as a promise.
- Resolved values become the response, exactly as if returned directly.
- Rejections respond with the rejection value in the console's error color and emit a warning.
- Cancellations respond with `Command cancelled.`

Waiting doesn't block the console. Commands run programmatically still wait for the promise, to ensure execution order.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
