### PR TITLE
fix: HasCharacter guard rejecting streamed-out players

### DIFF
--- a/Cmdr/BuiltInCommands/Admin/teleportServer.luau
+++ b/Cmdr/BuiltInCommands/Admin/teleportServer.luau
@@ -1,12 +1,15 @@
 const SEAT_TIMEOUT = 1
 
 const function teleportCharacter(humanoid: Humanoid, character: Model, cFrame: CFrame): boolean
-	if humanoid.SeatPart then
+	if humanoid.Sit then
+		const wasSeated = humanoid.SeatPart ~= nil
 		humanoid.Sit = false
 
-		const deadline = os.clock() + SEAT_TIMEOUT
-		while humanoid.SeatPart and os.clock() < deadline do
-			task.wait()
+		if wasSeated then
+			const deadline = os.clock() + SEAT_TIMEOUT
+			while humanoid.SeatPart and os.clock() < deadline do
+				task.wait()
+			end
 		end
 	end
 

--- a/Cmdr/BuiltInCommands/Admin/teleportServer.luau
+++ b/Cmdr/BuiltInCommands/Admin/teleportServer.luau
@@ -8,7 +8,7 @@ return function(_, fromPlayers: { Player }, destination: Player | Vector3): stri
 	for _, player: Player in ipairs(fromPlayers) do
 		const character = player.Character
 		const humanoid = character and character:FindFirstChildWhichIsA("Humanoid") :: Humanoid?
-		if not character or not humanoid then
+		if not humanoid then
 			continue
 		end
 

--- a/Cmdr/BuiltInCommands/Admin/teleportServer.luau
+++ b/Cmdr/BuiltInCommands/Admin/teleportServer.luau
@@ -3,12 +3,16 @@ return function(_, fromPlayers: { Player }, destination: Player | Vector3): stri
 		then (destination.Character :: Model):GetPivot()
 		else CFrame.new(destination)
 
+	local teleported = 0
+
 	for _, player: Player in ipairs(fromPlayers) do
 		const character = player.Character
-		const humanoid = character and character:FindFirstChildWhichIsA("Humanoid")
-		if not humanoid then
+		const humanoid = character and character:FindFirstChildWhichIsA("Humanoid") :: Humanoid?
+		if not character or not humanoid then
 			continue
 		end
+
+		teleported += 1
 
 		task.spawn(function()
 			if humanoid.SeatPart then
@@ -22,5 +26,9 @@ return function(_, fromPlayers: { Player }, destination: Player | Vector3): stri
 		end)
 	end
 
-	return `Teleported {#fromPlayers} players.`
+	if teleported == #fromPlayers then
+		return `Teleported {teleported} players.`
+	end
+
+	return `Teleported {teleported} of {#fromPlayers} players. The rest had no character.`
 end

--- a/Cmdr/BuiltInCommands/Admin/teleportServer.luau
+++ b/Cmdr/BuiltInCommands/Admin/teleportServer.luau
@@ -1,8 +1,29 @@
+const SEAT_TIMEOUT = 1
+
+const function teleportCharacter(humanoid: Humanoid, character: Model, cFrame: CFrame): boolean
+	if humanoid.SeatPart then
+		humanoid.Sit = false
+
+		const deadline = os.clock() + SEAT_TIMEOUT
+		while humanoid.SeatPart and os.clock() < deadline do
+			task.wait()
+		end
+	end
+
+	if not character:IsDescendantOf(workspace) then
+		return false
+	end
+
+	character:PivotTo(cFrame)
+	return true
+end
+
 return function(_, fromPlayers: { Player }, destination: Player | Vector3): string
 	const cFrame = if typeof(destination) == "Instance"
 		then (destination.Character :: Model):GetPivot()
 		else CFrame.new(destination)
 
+	local pending = 0
 	local teleported = 0
 
 	for _, player: Player in ipairs(fromPlayers) do
@@ -12,23 +33,26 @@ return function(_, fromPlayers: { Player }, destination: Player | Vector3): stri
 			continue
 		end
 
-		teleported += 1
+		pending += 1
 
 		task.spawn(function()
-			if humanoid.SeatPart then
-				humanoid.Sit = false
-				humanoid:GetPropertyChangedSignal("SeatPart"):Wait()
+			const ok, success = pcall(teleportCharacter, humanoid, character, cFrame)
+
+			if ok and success then
+				teleported += 1
 			end
 
-			if character:IsDescendantOf(workspace) then
-				character:PivotTo(cFrame)
-			end
+			pending -= 1
 		end)
+	end
+
+	while pending > 0 do
+		task.wait()
 	end
 
 	if teleported == #fromPlayers then
 		return `Teleported {teleported} players.`
 	end
 
-	return `Teleported {teleported} of {#fromPlayers} players. The rest had no character.`
+	return `Teleported {teleported} of {#fromPlayers} players.`
 end

--- a/Cmdr/BuiltInCommands/Debug/position.luau
+++ b/Cmdr/BuiltInCommands/Debug/position.luau
@@ -21,10 +21,17 @@ return {
 		HasCharacter(1),
 	},
 
-	ClientRun = function(_, player: Player): string
-		const character = player.Character :: Model
-		const rootPart = character:FindFirstChild("HumanoidRootPart") :: BasePart
+	ClientRun = function(_, player: Player): string?
+		const character = player.Character
+		const rootPart = character and character:FindFirstChild("HumanoidRootPart") :: BasePart?
+		if rootPart then
+			return (tostring(rootPart.Position):gsub("%s", ""))
+		end
 
-		return tostring(rootPart.Position):gsub("%s", "")
+		if player == Players.LocalPlayer then
+			return "You don't have a character."
+		end
+
+		return nil
 	end,
 }

--- a/Cmdr/BuiltInCommands/Debug/position.luau
+++ b/Cmdr/BuiltInCommands/Debug/position.luau
@@ -20,4 +20,14 @@ return {
 	Guards = {
 		HasCharacter(1),
 	},
+
+	ClientRun = function(_, player: Player): string?
+		const character = player.Character
+		const rootPart = character and character:FindFirstChild("HumanoidRootPart") :: BasePart?
+		if not rootPart then
+			return nil
+		end
+
+		return (tostring(rootPart.Position):gsub("%s", ""))
+	end,
 }

--- a/Cmdr/BuiltInCommands/Debug/position.luau
+++ b/Cmdr/BuiltInCommands/Debug/position.luau
@@ -20,18 +20,4 @@ return {
 	Guards = {
 		HasCharacter(1),
 	},
-
-	ClientRun = function(_, player: Player): string?
-		const character = player.Character
-		const rootPart = character and character:FindFirstChild("HumanoidRootPart") :: BasePart?
-		if rootPart then
-			return (tostring(rootPart.Position):gsub("%s", ""))
-		end
-
-		if player == Players.LocalPlayer then
-			return "You don't have a character."
-		end
-
-		return nil
-	end,
 }

--- a/Cmdr/BuiltInCommands/Debug/positionServer.luau
+++ b/Cmdr/BuiltInCommands/Debug/positionServer.luau
@@ -1,0 +1,11 @@
+return function(context: any, player: Player?): string
+	const target: Player? = player or context.Executor
+	const character = target and target.Character
+	const rootPart = character and character:FindFirstChild("HumanoidRootPart") :: BasePart?
+
+	if not rootPart then
+		return "Target player has no character."
+	end
+
+	return (tostring(rootPart.Position):gsub("%s", ""))
+end

--- a/Cmdr/CmdrClient/Shared/BuiltInGuards/HasCharacter.luau
+++ b/Cmdr/CmdrClient/Shared/BuiltInGuards/HasCharacter.luau
@@ -1,6 +1,11 @@
+const Players = game:GetService("Players")
+const RunService = game:GetService("RunService")
+
+const IS_SERVER = RunService:IsServer()
+
 const function hasValidCharacter(player: Player): boolean
 	const character = player.Character
-	return character ~= nil and character:FindFirstChild("HumanoidRootPart")
+	return character ~= nil and character:FindFirstChild("HumanoidRootPart") ~= nil
 end
 
 return function(index: number?)
@@ -19,9 +24,11 @@ return function(index: number?)
 		end
 
 		const players: { Player } = if isSingle then { target :: Player } else target :: { Player }
+		const canVerifyEveryone = IS_SERVER or not workspace.StreamingEnabled
 
 		for _, player in ipairs(players) do
-			if hasValidCharacter(player) then
+			const canVerify = canVerifyEveryone or player == Players.LocalPlayer
+			if not canVerify or hasValidCharacter(player) then
 				continue
 			end
 

--- a/docs/51-guards.md
+++ b/docs/51-guards.md
@@ -52,7 +52,7 @@ Cmdr processes guards sequentially in the order they are listed inside the `Guar
 
 Because command definitions are shared between client and server, guards are evaluated on the client first during UI invocation, and evaluated **again on the server** prior to running server code to prevent exploiters from bypassing client checks.
 
-Keep in mind that the client doesn't see everything the server does. With [`Workspace.StreamingEnabled`](https://create.roblox.com/docs/reference/engine/classes/Workspace#StreamingEnabled), for example, another player's character may not be replicated to the executor's client, so a client-side check can't tell the difference between "not there" and "not visible to me". Guards which inspect state the client might be missing should defer to the server (return `nil`) instead of rejecting the command, as the server check runs regardless.
+Keep in mind that the client doesn't see everything the server does. For example, with [`Workspace.StreamingEnabled`](https://create.roblox.com/docs/reference/engine/classes/Workspace#StreamingEnabled) another player's character might not be replicated to the executor's client, so a client-side check can't tell the difference between "not there" and "not visible to me". Guards which inspect state the client might be missing should defer to the server (return `nil`) instead of rejecting the command, as the server check runs regardless.
 
 Including [Hooks](/docs/hooks) and client functions, the full execution order is:
 

--- a/docs/51-guards.md
+++ b/docs/51-guards.md
@@ -52,6 +52,8 @@ Cmdr processes guards sequentially in the order they are listed inside the `Guar
 
 Because command definitions are shared between client and server, guards are evaluated on the client first during UI invocation, and evaluated **again on the server** prior to running server code to prevent exploiters from bypassing client checks.
 
+Keep in mind that the client doesn't see everything the server does. With [`Workspace.StreamingEnabled`](https://create.roblox.com/docs/reference/engine/classes/Workspace#StreamingEnabled), for example, another player's character may not be replicated to the executor's client, so a client-side check can't tell the difference between "not there" and "not visible to me". Guards which inspect state the client might be missing should defer to the server (return `nil`) instead of rejecting the command, as the server check runs regardless.
+
 Including [Hooks](/docs/hooks) and client functions, the full execution order is:
 
 1. `BeforeRun` hook on client.


### PR DESCRIPTION
With `Workspace.StreamingEnabled`, a distant player's character isn't replicated to the client, so the `HasCharacter` guard read "streamed out" as "no character" and killed `teleport` before it reached the server. The client now defers on players it can't see and lets the server decide, and `position` falls back to the server as well as `teleport` only counts players it actually moved.

**Declarations**:

- [x] I declare that this contribution was created in whole or in part by me.
- [x] I declare that I have the right to submit this contribution under the terms of this repository's license and declarations.
- [x] I understand and agree that this contribution and a record of it are public, maintained permanently, and may be redistributed under the terms of this repository's license.
